### PR TITLE
build: update to golang 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8.3
+  - 1.9.x
 
 # make build of forked repos work on travis (the forked repo contents will be
 # copied inside the right path)

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ bin/sircles: $(SIRCLES_DEPS) $(SIRCLES_SRC)
 
 # build the binary inside a docker container. Now we use a glibc based golang image to match the fedora base image used in the Dockerfile of the demo but can be changed to use a musl libc based image like alpine
 bin/sircles-dockerdemo: $(SIRCLES_WEBBUNDLE_DEPS) $(SIRCLES_WEBBUNDLE_SRC)
-	docker run --rm -v "$(PROJDIR)":/go/src/$(REPO_PATH) -w /go/src/$(REPO_PATH) golang:1.8 go build -tags webbundle -ldflags $(LD_FLAGS) -o /go/src/${REPO_PATH}/bin/sircles-dockerdemo $(REPO_PATH)/cmd/sircles
+	docker run --rm -v "$(PROJDIR)":/go/src/$(REPO_PATH) -w /go/src/$(REPO_PATH) golang:1.9 go build -tags webbundle -ldflags $(LD_FLAGS) -o /go/src/${REPO_PATH}/bin/sircles-dockerdemo $(REPO_PATH)/cmd/sircles
 
 .PHONY: dockerdemo
 dockerdemo: bin/sircles-dockerdemo


### PR DESCRIPTION
Use travis ".x" versioning to pull latest minor version.

Update dockerhub golang image to golang:1.9