### PR TITLE
graphql: reproducible roles, accountabilities, domains order

### DIFF
--- a/api/graphql/role.go
+++ b/api/graphql/role.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"context"
+	"sort"
 
 	"github.com/sorintlab/sircles/change"
 	"github.com/sorintlab/sircles/dataloader"
@@ -50,6 +51,7 @@ func (r *roleResolver) Domains() (*[]*domainResolver, error) {
 		return nil, err
 	}
 	domains := data.([]*models.Domain)
+	sort.Sort(models.Domains(domains))
 	l := make([]*domainResolver, len(domains))
 	for i, domain := range domains {
 		l[i] = &domainResolver{r.s, domain, r.timeLineID, r.dataLoaders}
@@ -63,6 +65,7 @@ func (r *roleResolver) Accountabilities() (*[]*accountabilityResolver, error) {
 		return nil, err
 	}
 	accountabilities := data.([]*models.Accountability)
+	sort.Sort(models.Accountabilities(accountabilities))
 	if err != nil {
 		return nil, err
 	}
@@ -116,6 +119,7 @@ func (r *roleResolver) Roles() (*[]*roleResolver, error) {
 		return nil, err
 	}
 	roles := data.([]*models.Role)
+	sort.Sort(models.Roles(roles))
 	l := make([]*roleResolver, len(roles))
 	for i, role := range roles {
 		l[i] = NewRoleResolver(r.s, role, r.timeLineID, r.dataLoaders)
@@ -323,6 +327,7 @@ func (r *circleMemberEdgeResolver) IsLeadLink() bool {
 }
 
 func (r *circleMemberEdgeResolver) FilledRoles() *[]*roleResolver {
+	sort.Sort(models.Roles(r.m.FilledRoles))
 	l := make([]*roleResolver, len(r.m.FilledRoles))
 	for i, role := range r.m.FilledRoles {
 		l[i] = NewRoleResolver(r.s, role, r.timeLineID, r.dataLoaders)
@@ -331,6 +336,7 @@ func (r *circleMemberEdgeResolver) FilledRoles() *[]*roleResolver {
 }
 
 func (r *circleMemberEdgeResolver) RepLink() *[]*roleResolver {
+	sort.Sort(models.Roles(r.m.RepLink))
 	l := make([]*roleResolver, len(r.m.RepLink))
 	for i, role := range r.m.RepLink {
 		l[i] = NewRoleResolver(r.s, role, r.timeLineID, r.dataLoaders)
@@ -363,6 +369,7 @@ func (r *memberCircleEdgeResolver) IsLeadLink() bool {
 }
 
 func (r *memberCircleEdgeResolver) FilledRoles() *[]*roleResolver {
+	sort.Sort(models.Roles(r.m.FilledRoles))
 	l := make([]*roleResolver, len(r.m.FilledRoles))
 	for i, role := range r.m.FilledRoles {
 		l[i] = NewRoleResolver(r.s, role, r.timeLineID, r.dataLoaders)
@@ -371,6 +378,7 @@ func (r *memberCircleEdgeResolver) FilledRoles() *[]*roleResolver {
 }
 
 func (r *memberCircleEdgeResolver) RepLink() *[]*roleResolver {
+	sort.Sort(models.Roles(r.m.RepLink))
 	l := make([]*roleResolver, len(r.m.RepLink))
 	for i, role := range r.m.RepLink {
 		l[i] = NewRoleResolver(r.s, role, r.timeLineID, r.dataLoaders)

--- a/api/graphql/schema_test.go
+++ b/api/graphql/schema_test.go
@@ -87,28 +87,48 @@ var rootResponse = `
 			{
 				"accountabilities": [
 					{
-						"description": "Structuring the Governance of the Circle to enact its Purpose and Accountabilities",
-						"uid": "FWiC2SYxTVGUoiEZ4qdGEG"
+						"description": "Auditing the meetings and records of Sub-Circles as needed, and declaring a Process Breakdown upon discovering a pattern of behavior that conflicts with the rules of the Constitution",
+						"uid": "Se8a4DvgYq2cJ9UEDqgKNM"
+					},
+					{
+						"description": "Facilitating the Circle’s constitutionally-required meetings",
+						"uid": "gmZoeT8F28tM7kSDbmZmzW"
+					}
+				],
+				"circleMembers": [],
+				"depth": 1,
+				"domains": [],
+				"name": "Facilitator",
+				"purpose": "Circle governance and operational practices aligned with the Constitution",
+				"roleMembers": [],
+				"roleType": "facilitator",
+				"uid": "QEWLthRuui9iS2WJstNQL5"
+			},
+			{
+				"accountabilities": [
+					{
+						"description": "Allocating the Circle’s resources across its various Projects and/or Roles",
+						"uid": "2ohBfpApdb3apZknrsqGb8"
 					},
 					{
 						"description": "Assigning Partners to the Circle’s Roles; monitoring the fit; offering feedback to enhance fit; and re-assigning Roles to other Partners when useful for enhancing fit",
 						"uid": "KPaMkcYEKciFbucjfb3HC9"
 					},
 					{
-						"description": "Allocating the Circle’s resources across its various Projects and/or Roles",
-						"uid": "2ohBfpApdb3apZknrsqGb8"
+						"description": "Defining metrics for the circle",
+						"uid": "a62CFULXsJwqaxw6jbxRKM"
 					},
 					{
 						"description": "Establishing priorities and Strategies for the Circle",
 						"uid": "RpWWJJYDbG62C3VEs7Ebum"
 					},
 					{
-						"description": "Defining metrics for the circle",
-						"uid": "a62CFULXsJwqaxw6jbxRKM"
-					},
-					{
 						"description": "Removing constraints within the Circle to the Super-Circle enacting its Purpose and Accountabilities",
 						"uid": "gnuMbXaA2G9xwk9qZ34eum"
+					},
+					{
+						"description": "Structuring the Governance of the Circle to enact its Purpose and Accountabilities",
+						"uid": "FWiC2SYxTVGUoiEZ4qdGEG"
 					}
 				],
 				"circleMembers": [],
@@ -128,36 +148,16 @@ var rootResponse = `
 			{
 				"accountabilities": [
 					{
-						"description": "Facilitating the Circle’s constitutionally-required meetings",
-						"uid": "gmZoeT8F28tM7kSDbmZmzW"
-					},
-					{
-						"description": "Auditing the meetings and records of Sub-Circles as needed, and declaring a Process Breakdown upon discovering a pattern of behavior that conflicts with the rules of the Constitution",
-						"uid": "Se8a4DvgYq2cJ9UEDqgKNM"
-					}
-				],
-				"circleMembers": [],
-				"depth": 1,
-				"domains": [],
-				"name": "Facilitator",
-				"purpose": "Circle governance and operational practices aligned with the Constitution",
-				"roleMembers": [],
-				"roleType": "facilitator",
-				"uid": "QEWLthRuui9iS2WJstNQL5"
-			},
-			{
-				"accountabilities": [
-					{
-						"description": "Scheduling the Circle’s required meetings, and notifying all Core Circle Members of scheduled times and locations",
-						"uid": "yVgcf2FvMLvApmH4oth8ZG"
-					},
-					{
 						"description": "Capturing and publishing the outputs of the Circle’s required meetings, and maintaining a compiled view of the Circle’s current Governance, checklist items, and metrics",
 						"uid": "5qWPGXXtCZDJZbYCsHCBrn"
 					},
 					{
 						"description": "Interpreting Governance and the Constitution upon request",
 						"uid": "cp3LhNyZ9emRTZWWaqs9ej"
+					},
+					{
+						"description": "Scheduling the Circle’s required meetings, and notifying all Core Circle Members of scheduled times and locations",
+						"uid": "yVgcf2FvMLvApmH4oth8ZG"
 					}
 				],
 				"circleMembers": [],
@@ -1135,9 +1135,9 @@ func TestCircleCreateChildRole(t *testing.T) {
 						"uid": "RoaZnj2aFt5gSyt3Q9v5vm",
 						"depth": 1,
 						"roles": [
+							{"name":"Facilitator", "depth": 2},
 							{"name":"Lead Link", "depth": 2},
 							{"name":"Rep Link", "depth": 2},
-							{"name":"Facilitator", "depth": 2},
 							{"name":"Secretary", "depth": 2},
 							{"name":"rootRole-circle01", "depth": 2}
 						]
@@ -1170,17 +1170,17 @@ func TestCircleCreateChildRole(t *testing.T) {
 				"rootRole": {
 					"name": "General",
 					"roles": [
-						{ "name": "Lead Link", "roleType": "leadlink", "depth": 1 },
 						{ "name": "Facilitator", "roleType": "facilitator", "depth": 1 },
+						{ "name": "Lead Link", "roleType": "leadlink", "depth": 1 },
 						{ "name": "Secretary", "roleType": "secretary", "depth": 1 },
-						{ "name": "rootRole-role01", "roleType": "normal", "depth": 1 },
-						{ "name": "rootRole-role02", "roleType": "normal", "depth": 1 },
-						{ "name": "rootRole-role03", "roleType": "normal", "depth": 1 },
-						{ "name": "rootRole-role04", "roleType": "normal", "depth": 1 },
 						{ "name": "rootRole-circle02", "roleType": "circle", "depth": 1 },
 						{ "name": "rootRole-circle03", "roleType": "circle", "depth": 1 },
 						{ "name": "rootRole-circle04", "roleType": "circle", "depth": 1 },
-						{ "name": "rootRole-newcircle", "roleType": "circle", "depth": 1 }
+						{ "name": "rootRole-newcircle", "roleType": "circle", "depth": 1 },
+						{ "name": "rootRole-role01", "roleType": "normal", "depth": 1 },
+						{ "name": "rootRole-role02", "roleType": "normal", "depth": 1 },
+						{ "name": "rootRole-role03", "roleType": "normal", "depth": 1 },
+						{ "name": "rootRole-role04", "roleType": "normal", "depth": 1 }
 					]
 				}
 			}
@@ -1376,16 +1376,16 @@ func TestCircleDeleteChildRole(t *testing.T) {
 				"rootRole": {
 					"name": "General",
 					"roles": [
-						{ "name": "Lead Link" },
 						{ "name": "Facilitator" },
+						{ "name": "Lead Link" },
 						{ "name": "Secretary" },
+						{ "name": "rootRole-circle02" },
+						{ "name": "rootRole-circle03" },
+						{ "name": "rootRole-circle04" },
 						{ "name": "rootRole-role01" },
 						{ "name": "rootRole-role02" },
 						{ "name": "rootRole-role03" },
-						{ "name": "rootRole-role04" },
-						{ "name": "rootRole-circle02" },
-						{ "name": "rootRole-circle03" },
-						{ "name": "rootRole-circle04" }
+						{ "name": "rootRole-role04" }
 					]
 				}
 			}
@@ -1413,39 +1413,17 @@ func TestCircleDeleteChildRole(t *testing.T) {
 				"rootRole": {
 					"name": "General",
 					"roles": [
-						{
-							"name": "Lead Link"
-						},
-						{
-							"name": "Facilitator"
-						},
-						{
-							"name": "Secretary"
-						},
-						{
-							"name": "rootRole-role01"
-						},
-						{
-							"name": "rootRole-role02"
-						},
-						{
-							"name": "rootRole-role03"
-						},
-						{
-							"name": "rootRole-role04"
-						},
-						{
-							"name": "rootRole-circle01"
-						},
-						{
-							"name": "rootRole-circle02"
-						},
-						{
-							"name": "rootRole-circle03"
-						},
-						{
-							"name": "rootRole-circle04"
-						}
+						{ "name": "Facilitator" },
+						{ "name": "Lead Link" },
+						{ "name": "Secretary" },
+						{ "name": "rootRole-circle01" },
+						{ "name": "rootRole-circle02" },
+						{ "name": "rootRole-circle03" },
+						{ "name": "rootRole-circle04" },
+						{ "name": "rootRole-role01" },
+						{ "name": "rootRole-role02" },
+						{ "name": "rootRole-role03" },
+						{ "name": "rootRole-role04" }
 					]
 				}
 			}
@@ -1504,17 +1482,17 @@ func TestCircleDeleteChildRole(t *testing.T) {
 				"rootRole": {
 					"name": "General",
 					"roles": [
-						{ "name": "Lead Link", "roleType": "leadlink", "depth": 1 },
 						{ "name": "Facilitator", "roleType": "facilitator", "depth": 1 },
+						{ "name": "Lead Link", "roleType": "leadlink", "depth": 1 },
 						{ "name": "Secretary", "roleType": "secretary", "depth": 1 },
-						{ "name": "rootRole-role01", "roleType": "normal", "depth": 1 },
-						{ "name": "rootRole-role02", "roleType": "normal", "depth": 1 },
-						{ "name": "rootRole-role03", "roleType": "normal", "depth": 1 },
-						{ "name": "rootRole-role04", "roleType": "normal", "depth": 1 },
+						{ "name": "rootRole-circle01-role01", "roleType": "normal", "depth": 1 },
 						{ "name": "rootRole-circle02", "roleType": "circle", "depth": 1 },
 						{ "name": "rootRole-circle03", "roleType": "circle", "depth": 1 },
 						{ "name": "rootRole-circle04", "roleType": "circle", "depth": 1 },
-						{ "name": "rootRole-circle01-role01", "roleType": "normal", "depth": 1 }
+						{ "name": "rootRole-role01", "roleType": "normal", "depth": 1 },
+						{ "name": "rootRole-role02", "roleType": "normal", "depth": 1 },
+						{ "name": "rootRole-role03", "roleType": "normal", "depth": 1 },
+						{ "name": "rootRole-role04", "roleType": "normal", "depth": 1 }
 					]
 				}
 			}
@@ -1542,17 +1520,17 @@ func TestCircleDeleteChildRole(t *testing.T) {
 				"rootRole": {
 					"name": "General",
 					"roles": [
-						{ "name": "Lead Link" },
 						{ "name": "Facilitator" },
+						{ "name": "Lead Link" },
 						{ "name": "Secretary" },
-						{ "name": "rootRole-role01" },
-						{ "name": "rootRole-role02" },
-						{ "name": "rootRole-role03" },
-						{ "name": "rootRole-role04" },
 						{ "name": "rootRole-circle01" },
 						{ "name": "rootRole-circle02" },
 						{ "name": "rootRole-circle03" },
-						{ "name": "rootRole-circle04" }
+						{ "name": "rootRole-circle04" },
+						{ "name": "rootRole-role01" },
+						{ "name": "rootRole-role02" },
+						{ "name": "rootRole-role03" },
+						{ "name": "rootRole-role04" }
 					]
 				}
 			}
@@ -1991,18 +1969,18 @@ func TestCircleUpdateChildRole(t *testing.T) {
 				"rootRole": {
 					"name": "General",
 					"roles": [
-						{ "name": "Lead Link", "roleType": "leadlink", "depth": 1 },
 						{ "name": "Facilitator", "roleType": "facilitator", "depth": 1 },
+						{ "name": "Lead Link", "roleType": "leadlink", "depth": 1 },
 						{ "name": "Secretary", "roleType": "secretary", "depth": 1 },
-						{ "name": "rootRole-role01", "roleType": "normal", "depth": 1 },
-						{ "name": "rootRole-role02", "roleType": "normal", "depth": 1 },
-						{ "name": "rootRole-role03", "roleType": "normal", "depth": 1 },
-						{ "name": "rootRole-role04", "roleType": "normal", "depth": 1 },
 						{ "name": "rootRole-circle01", "roleType": "normal", "depth": 1 },
+						{ "name": "rootRole-circle01-role01", "roleType": "normal", "depth": 1 },
 						{ "name": "rootRole-circle02", "roleType": "circle", "depth": 1 },
 						{ "name": "rootRole-circle03", "roleType": "circle", "depth": 1 },
 						{ "name": "rootRole-circle04", "roleType": "circle", "depth": 1 },
-						{ "name": "rootRole-circle01-role01", "roleType": "normal", "depth": 1 }
+						{ "name": "rootRole-role01", "roleType": "normal", "depth": 1 },
+						{ "name": "rootRole-role02", "roleType": "normal", "depth": 1 },
+						{ "name": "rootRole-role03", "roleType": "normal", "depth": 1 },
+						{ "name": "rootRole-role04", "roleType": "normal", "depth": 1 }
 					]
 				}
 			}
@@ -2030,17 +2008,17 @@ func TestCircleUpdateChildRole(t *testing.T) {
 				"rootRole": {
 					"name": "General",
 					"roles": [
-						{ "name": "Lead Link" },
 						{ "name": "Facilitator" },
+						{ "name": "Lead Link" },
 						{ "name": "Secretary" },
-						{ "name": "rootRole-role01" },
-						{ "name": "rootRole-role02" },
-						{ "name": "rootRole-role03" },
-						{ "name": "rootRole-role04" },
 						{ "name": "rootRole-circle01" },
 						{ "name": "rootRole-circle02" },
 						{ "name": "rootRole-circle03" },
-						{ "name": "rootRole-circle04" }
+						{ "name": "rootRole-circle04" },
+						{ "name": "rootRole-role01" },
+						{ "name": "rootRole-role02" },
+						{ "name": "rootRole-role03" },
+						{ "name": "rootRole-role04" }
 					]
 				}
 			}

--- a/models/accountability.go
+++ b/models/accountability.go
@@ -5,3 +5,9 @@ type Accountability struct {
 	Version     uint64
 	Description string
 }
+
+type Accountabilities []*Accountability
+
+func (a Accountabilities) Len() int           { return len(a) }
+func (a Accountabilities) Less(i, j int) bool { return a[i].Description < a[j].Description }
+func (a Accountabilities) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }

--- a/models/domain.go
+++ b/models/domain.go
@@ -4,3 +4,9 @@ type Domain struct {
 	Vertex
 	Description string
 }
+
+type Domains []*Domain
+
+func (d Domains) Len() int           { return len(d) }
+func (d Domains) Less(i, j int) bool { return d[i].Description < d[j].Description }
+func (d Domains) Swap(i, j int)      { d[i], d[j] = d[j], d[i] }

--- a/models/role.go
+++ b/models/role.go
@@ -52,6 +52,12 @@ type Role struct {
 	Purpose  string
 }
 
+type Roles []*Role
+
+func (r Roles) Len() int           { return len(r) }
+func (r Roles) Less(i, j int) bool { return r[i].Name < r[j].Name }
+func (r Roles) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+
 type RoleAdditionalContent struct {
 	Vertex
 	Content string


### PR DESCRIPTION
sort roles, accountabilities and domains by name to make them reproducible also
on postgres. It wasn't an issue with sqlite3 because they are returned in the
insert order.

This is needed to run tests using postgres instead of sqlite3.