### PR TITLE
db: call migrate outside NewDB

### DIFF
--- a/api/graphql/schema_test.go
+++ b/api/graphql/schema_test.go
@@ -466,6 +466,11 @@ func RunTests(t *testing.T, initFunc initFunc, tests []*Test) {
 		log.Fatalf("unknown db type")
 	}
 
+	// Populate/migrate db
+	if err := tdb.Migrate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
 	defer tdb.Close()
 
 	resolver := NewResolver()

--- a/cmd/sircles/dump.go
+++ b/cmd/sircles/dump.go
@@ -63,6 +63,11 @@ func dump(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Populate/migrate db
+	if err := db.Migrate(); err != nil {
+		return err
+	}
+
 	tx, err := db.NewTx()
 	if err != nil {
 		return err

--- a/cmd/sircles/restore.go
+++ b/cmd/sircles/restore.go
@@ -68,6 +68,11 @@ func restore(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Populate/migrate db
+	if err := db.Migrate(); err != nil {
+		return err
+	}
+
 	tx, err := db.NewTx()
 	if err != nil {
 		return err

--- a/cmd/sircles/server.go
+++ b/cmd/sircles/server.go
@@ -143,6 +143,11 @@ func serve(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Populate/migrate db
+	if err := db.Migrate(); err != nil {
+		return err
+	}
+
 	var authenticator auth.Authenticator
 
 	switch c.Authentication.Type {

--- a/db/db.go
+++ b/db/db.go
@@ -129,11 +129,6 @@ func NewDB(dbType, dbConnString string) (*DB, error) {
 		t:  t,
 	}
 
-	// Populate/migrate db
-	if err := db.migrate(); err != nil {
-		return nil, err
-	}
-
 	return db, nil
 }
 

--- a/db/migration.go
+++ b/db/migration.go
@@ -13,7 +13,7 @@ const migrationTableDDL = `
 	create table if not exists migration (version int not null, time timestamptz not null)
 `
 
-func (db *DB) migrate() error {
+func (db *DB) Migrate() error {
 	tx, err := db.NewTx()
 	if err != nil {
 		return err

--- a/eventstore/eventstore_test.go
+++ b/eventstore/eventstore_test.go
@@ -70,6 +70,9 @@ func TestWriteEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	tx, err := db.NewTx()
 	if err != nil {
@@ -172,6 +175,9 @@ func TestRestoreEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if err := db1.Migrate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	tx, err := db1.NewTx()
 	if err != nil {
@@ -203,6 +209,9 @@ func TestRestoreEvents(t *testing.T) {
 
 	db2, err := db.NewDB("sqlite3", dbpath)
 	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := db2.Migrate(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
in future the migrate function will be split and moved to its related db (eventstore,
readdb etc...)

This change is needed to be able to reuse the db methods also for local
aggregate snapshot/caches.