### PR TITLE
*: improve error handling

### DIFF
--- a/api/graphql/schema.go
+++ b/api/graphql/schema.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -20,6 +18,7 @@ import (
 	"github.com/sorintlab/sircles/util"
 
 	graphql "github.com/neelance/graphql-go"
+	"github.com/pkg/errors"
 	"github.com/renstrom/shortuuid"
 	"github.com/satori/go.uuid"
 )
@@ -599,7 +598,7 @@ func unmarshalUID(uid graphql.ID) (util.ID, error) {
 	if err != nil {
 		id, err = uuid.FromString(string(uid))
 		if err != nil {
-			return util.NilID, fmt.Errorf("cannot unmarshall uid %q: %v", uid, err)
+			return util.NilID, errors.Wrapf(err, "cannot unmarshall uid %q", uid)
 		}
 	}
 	return util.NewFromUUID(id), nil
@@ -1270,7 +1269,7 @@ func getTimeLineNumber(readDB readdb.ReadDB, v *util.TimeLineNumber) (util.TimeL
 
 	if timeLineID < 0 {
 		if !test {
-			return 0, fmt.Errorf("invalid timeLineID %d", *v)
+			return 0, errors.Errorf("invalid timeLineID %d", *v)
 		}
 
 		// TODO(sgotti) ugly hack used only for tests, should to be removed
@@ -1282,7 +1281,7 @@ func getTimeLineNumber(readDB readdb.ReadDB, v *util.TimeLineNumber) (util.TimeL
 			return 0, err
 		}
 		if len(tls) < n {
-			return 0, fmt.Errorf("invalid timeLineID %d", *v)
+			return 0, errors.Errorf("invalid timeLineID %d", *v)
 		}
 		timeLineID = tls[n-1].Number()
 	}

--- a/api/graphql/search.go
+++ b/api/graphql/search.go
@@ -2,13 +2,13 @@ package graphql
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/sorintlab/sircles/dataloader"
 	"github.com/sorintlab/sircles/readdb"
 
 	"github.com/blevesearch/bleve"
 	graphql "github.com/neelance/graphql-go"
+	"github.com/pkg/errors"
 )
 
 type searchResultResolver struct {
@@ -35,7 +35,7 @@ func (r *searchResultResolver) Hits() []graphql.ID {
 func (r *searchResultResolver) Result() (string, error) {
 	res, err := json.Marshal(r.res)
 	if err != nil {
-		return "", fmt.Errorf("error marshalling search result: %v", err)
+		return "", errors.Wrapf(err, "error marshalling search result")
 	}
 
 	return string(res), nil

--- a/auth/ldap.go
+++ b/auth/ldap.go
@@ -179,7 +179,7 @@ func (c *ldapAuthenticator) UserEntry(conn *ldap.Conn, searchData *searchData) (
 
 	switch n := len(resp.Entries); n {
 	case 0:
-		log.Errorf("ldap: no results returned for filter: %q", filter)
+		errors.Errorf("ldap: no results returned for filter: %q", filter)
 		return nil, nil
 	case 1:
 		return resp.Entries[0], nil
@@ -313,7 +313,7 @@ func (c *ldapMemberProvider) UserEntry(conn *ldap.Conn, searchData *searchData) 
 
 	switch n := len(resp.Entries); n {
 	case 0:
-		log.Errorf("ldap: no results returned for filter: %q", req.Filter)
+		errors.Errorf("ldap: no results returned for filter: %q", req.Filter)
 		return nil, nil
 	case 1:
 		return resp.Entries[0], nil

--- a/cmd/sircles/dump.go
+++ b/cmd/sircles/dump.go
@@ -40,7 +40,7 @@ func dump(cmd *cobra.Command, args []string) error {
 
 	c, err := config.Parse(configFile)
 	if err != nil {
-		return fmt.Errorf("error parsing configuration file %s: %v", configFile, err)
+		return errors.WithMessage(err, fmt.Sprintf("error parsing configuration file %s", configFile))
 	}
 
 	if c.Debug {
@@ -55,7 +55,7 @@ func dump(cmd *cobra.Command, args []string) error {
 	case db.CockRoachDB:
 	case db.Sqlite3:
 	default:
-		return fmt.Errorf("unsupported db type: %s", c.DB.Type)
+		return errors.Errorf("unsupported db type: %s", c.DB.Type)
 	}
 
 	db, err := db.NewDB(c.DB.Type, c.DB.ConnString)
@@ -96,11 +96,11 @@ func dump(cmd *cobra.Command, args []string) error {
 		for _, event := range events {
 			log.Infof("sequencenumber: %d", event.SequenceNumber)
 			if event.SequenceNumber != lastSeqNumber {
-				panic(fmt.Errorf("sequence number: %d != %d", event.SequenceNumber, lastSeqNumber))
+				panic(errors.Errorf("sequence number: %d != %d", event.SequenceNumber, lastSeqNumber))
 			}
 			eventj, err := json.Marshal(event)
 			if err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 			f.Write(eventj)
 			f.Write([]byte("\n"))

--- a/cmd/sircles/restore.go
+++ b/cmd/sircles/restore.go
@@ -45,7 +45,7 @@ func restore(cmd *cobra.Command, args []string) error {
 
 	c, err := config.Parse(configFile)
 	if err != nil {
-		return fmt.Errorf("error parsing configuration file %s: %v", configFile, err)
+		return errors.WithMessage(err, fmt.Sprintf("error parsing configuration file %s", configFile))
 	}
 
 	if c.Debug {
@@ -60,7 +60,7 @@ func restore(cmd *cobra.Command, args []string) error {
 	case db.CockRoachDB:
 	case db.Sqlite3:
 	default:
-		return fmt.Errorf("unsupported db type: %s", c.DB.Type)
+		return errors.Errorf("unsupported db type: %s", c.DB.Type)
 	}
 
 	db, err := db.NewDB(c.DB.Type, c.DB.ConnString)

--- a/config/config.go
+++ b/config/config.go
@@ -2,24 +2,24 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
 	"github.com/sorintlab/sircles/db"
 )
 
 func Parse(configFile string) (*Config, error) {
 	configData, err := ioutil.ReadFile(configFile)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	c := &defaultConfig
 	if err := yaml.Unmarshal(configData, &c); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return c, nil
@@ -122,17 +122,17 @@ func (s *Authentication) UnmarshalJSON(b []byte) error {
 		Config json.RawMessage `json:"config"`
 	}
 	if err := json.Unmarshal(b, &auth); err != nil {
-		return fmt.Errorf("failed to parse authentication config: %v", err)
+		return errors.Wrapf(err, "failed to parse authentication config")
 	}
 	f, ok := authConfigs[auth.Type]
 	if !ok {
-		return fmt.Errorf("unknown authentication type %q", auth.Type)
+		return errors.Errorf("unknown authentication type %q", auth.Type)
 	}
 
 	authConfig := f()
 	if len(auth.Config) != 0 {
 		if err := json.Unmarshal(auth.Config, authConfig); err != nil {
-			return fmt.Errorf("failed to parse authentication config: %v", err)
+			return errors.Wrapf(err, "failed to parse authentication config")
 		}
 	}
 	*s = Authentication{
@@ -247,17 +247,17 @@ func (s *MemberProvider) UnmarshalJSON(b []byte) error {
 		Config json.RawMessage `json:"config"`
 	}
 	if err := json.Unmarshal(b, &memberProvider); err != nil {
-		return fmt.Errorf("failed to parse memberProvider config: %v", err)
+		return errors.Wrapf(err, "failed to parse memberProvider config")
 	}
 	f, ok := memberProviderConfigs[memberProvider.Type]
 	if !ok {
-		return fmt.Errorf("unknown member provider type %q", memberProvider.Type)
+		return errors.Errorf("unknown member provider type %q", memberProvider.Type)
 	}
 
 	memberProviderConfig := f()
 	if len(memberProvider.Config) != 0 {
 		if err := json.Unmarshal(memberProvider.Config, memberProviderConfig); err != nil {
-			return fmt.Errorf("failed to parse member provider config: %v", err)
+			return errors.Wrapf(err, "failed to parse member provider config")
 		}
 	}
 	*s = MemberProvider{

--- a/eventstore/eventstore.go
+++ b/eventstore/eventstore.go
@@ -72,7 +72,7 @@ func scanEvents(rows *sql.Rows) ([]*Event, error) {
 		events = append(events, m)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return events, nil
 }
@@ -99,7 +99,7 @@ func scanAggregatesVersion(rows *sql.Rows) ([]*AggregateVersion, error) {
 		aggregatesVersion = append(aggregatesVersion, a)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return aggregatesVersion, nil
 }

--- a/readdb/readdb.go
+++ b/readdb/readdb.go
@@ -299,7 +299,7 @@ func (s *DBService) vertices(tl util.TimeLineNumber, vertexClass vertexClass, li
 	err = s.tx.Do(func(tx *db.WrappedTx) error {
 		rows, err := tx.Query(q, args...)
 		if err != nil {
-			return errors.Wrap(err, "failed to execute query")
+			return errors.WithMessage(err, "failed to execute query")
 		}
 
 		switch vertexClass {
@@ -629,7 +629,7 @@ func (s *DBService) closeVertex(endtl util.TimeLineNumber, vc vertexClass, id ut
 		return err
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to execute query")
+		return errors.WithMessage(err, "failed to execute query")
 	}
 	return nil
 }
@@ -701,7 +701,7 @@ func (s *DBService) closeEdge(endtl util.TimeLineNumber, ec edgeClass, x, y util
 		return err
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to execute query")
+		return errors.WithMessage(err, "failed to execute query")
 	}
 	return nil
 }
@@ -1173,7 +1173,7 @@ func (s *DBService) insertRole(tl util.TimeLineNumber, id util.ID, role *models.
 		return err
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to execute query")
+		return errors.WithMessage(err, "failed to execute query")
 	}
 	return nil
 }
@@ -1188,7 +1188,7 @@ func (s *DBService) insertDomain(tl util.TimeLineNumber, id util.ID, domain *mod
 		return err
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to execute query")
+		return errors.WithMessage(err, "failed to execute query")
 	}
 	return nil
 }
@@ -1203,7 +1203,7 @@ func (s *DBService) insertAccountability(tl util.TimeLineNumber, id util.ID, acc
 		return err
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to execute query")
+		return errors.WithMessage(err, "failed to execute query")
 	}
 	return nil
 }
@@ -1218,7 +1218,7 @@ func (s *DBService) insertRoleAdditionalContent(tl util.TimeLineNumber, id util.
 		return err
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to execute query")
+		return errors.WithMessage(err, "failed to execute query")
 	}
 	return nil
 }
@@ -1233,7 +1233,7 @@ func (s *DBService) insertMember(tl util.TimeLineNumber, id util.ID, member *mod
 		return err
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to execute query")
+		return errors.WithMessage(err, "failed to execute query")
 	}
 	return nil
 }
@@ -1248,7 +1248,7 @@ func (s *DBService) insertMemberAvatar(tl util.TimeLineNumber, id util.ID, avata
 		return err
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to execute query")
+		return errors.WithMessage(err, "failed to execute query")
 	}
 	return nil
 }
@@ -1263,7 +1263,7 @@ func (s *DBService) insertTension(tl util.TimeLineNumber, id util.ID, tension *m
 		return err
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to execute query")
+		return errors.WithMessage(err, "failed to execute query")
 	}
 	return nil
 }
@@ -1287,7 +1287,7 @@ func (s *DBService) insertRoleEvent(roleEvent *models.RoleEvent) error {
 		return err
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to execute query")
+		return errors.WithMessage(err, "failed to execute query")
 	}
 	return nil
 }
@@ -1536,7 +1536,7 @@ func (s *DBService) RoleEventsByTypeInternal(roleID util.ID, tl util.TimeLineNum
 	err = s.tx.Do(func(tx *db.WrappedTx) error {
 		rows, err := tx.Query(q, args...)
 		if err != nil {
-			return errors.Wrap(err, "failed to execute query")
+			return errors.WithMessage(err, "failed to execute query")
 		}
 		events, err = scanRoleEvents(rows)
 		return err
@@ -1582,7 +1582,7 @@ func (s *DBService) RoleEventsInternal(roleID util.ID, first int, start, after u
 	err = s.tx.Do(func(tx *db.WrappedTx) error {
 		rows, err := tx.Query(q, args...)
 		if err != nil {
-			return errors.Wrap(err, "failed to execute query")
+			return errors.WithMessage(err, "failed to execute query")
 		}
 		events, err = scanRoleEvents(rows)
 		return err
@@ -3358,7 +3358,7 @@ func (s *DBService) changeRoleParent(nextTl util.TimeLineNumber, roleID util.ID,
 		return err
 	}
 	if role == nil {
-		return fmt.Errorf("role with id %d doesn't exist", roleID)
+		return errors.Errorf("role with id %d doesn't exist", roleID)
 	}
 	depth := int32(0)
 	if newParentID != nil {

--- a/util/graphql.go
+++ b/util/graphql.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // We have int64 timelines but javascript cannot handle 64 bit
@@ -22,7 +24,7 @@ func (tl *TimeLineNumber) UnmarshalGraphQL(input interface{}) error {
 	case string:
 		t, err := strconv.ParseInt(input, 10, 64)
 		if err != nil {
-			return fmt.Errorf("cannot parse timeline %v: %v", input, err)
+			return errors.Wrapf(err, "cannot parse timeline %v", input)
 		}
 		*tl = TimeLineNumber(t)
 		return nil
@@ -31,7 +33,7 @@ func (tl *TimeLineNumber) UnmarshalGraphQL(input interface{}) error {
 		*tl = TimeLineNumber(int64(input))
 		return nil
 	default:
-		return fmt.Errorf("wrong type: %T", input)
+		return errors.Errorf("wrong type: %T", input)
 	}
 }
 


### PR DESCRIPTION
Try to provide a proper stack trace without adding redundant stack traces. For
how pkg/errors works this is currently a manual and error prone work. The rules
are these:

* Use errors.New/Errorf when creating a new error, this will save a stacktrace
* Use errors.Wrap/Wrapf/WithStack when calling an external library that doens't return an
error with a stacktrace
* Just return the errors or use errors.WithMessage when returning an error
generated inside the app or a library that returns an error that already have
a stacktrace
* For errors returned with a channel by another go routine it's useful to record
also another stacktrace using errors.Wrap/Wrapf/WithStack.

Also use #+v when logging errors to also print the stacktrace (we aren't
currently using zap as a structured logger, in that case zap will automatically
add an ErrorVerbose field on errors with a stacktrace).