### PR TITLE
eventstore: make AggregateID a string

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -266,7 +266,7 @@ func (s *CommandService) UpdateRootRole(ctx context.Context, c *change.UpdateRoo
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeUpdateRootRole, callingMember.ID, &commands.UpdateRootRole{UpdateRootRoleChange: *c})
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	if c.NameChanged {
@@ -372,7 +372,7 @@ func (s *CommandService) UpdateRootRole(ctx context.Context, c *change.UpdateRoo
 		events = events.AddEvent(eventstore.NewEventRoleAccountabilityUpdated(&correlationID, &causationID, &groupID, role.ID, accountability))
 	}
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -498,7 +498,7 @@ func (s *CommandService) CircleCreateChildRole(ctx context.Context, roleID util.
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeCircleCreateChildRole, callingMember.ID, &commands.CircleCreateChildRole{RoleID: roleID, CreateRoleChange: *c})
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	role := &models.Role{
@@ -550,7 +550,7 @@ func (s *CommandService) CircleCreateChildRole(ctx context.Context, roleID util.
 		}
 	}
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -698,7 +698,7 @@ func (s *CommandService) CircleUpdateChildRole(ctx context.Context, roleID util.
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeCircleUpdateChildRole, callingMember.ID, &commands.CircleUpdateChildRole{RoleID: roleID, UpdateRoleChange: *c})
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	childsGroups, err := s.readDB.ChildRolesInternal(curTlSeq, []util.ID{role.ID}, nil)
@@ -945,7 +945,7 @@ func (s *CommandService) CircleUpdateChildRole(ctx context.Context, roleID util.
 		events = events.AddEvent(eventstore.NewEventRoleAccountabilityUpdated(&correlationID, &causationID, &groupID, role.ID, accountability))
 	}
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -1174,7 +1174,7 @@ func (s *CommandService) CircleDeleteChildRole(ctx context.Context, roleID util.
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeCircleDeleteChildRole, callingMember.ID, &commands.CircleDeleteChildRole{RoleID: roleID, DeleteRoleChange: *c})
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	skipchilds := []util.ID{}
@@ -1197,7 +1197,7 @@ func (s *CommandService) CircleDeleteChildRole(ctx context.Context, roleID util.
 	}
 	events = events.AddEvents(es)
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -1261,12 +1261,12 @@ func (s *CommandService) SetRoleAdditionalContent(ctx context.Context, roleID ut
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeSetRoleAdditionalContent, callingMember.ID, commands.SetRoleAdditionalContent{RoleID: roleID, Content: content})
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	events = events.AddEvent(eventstore.NewEventRoleAdditionalContentSet(&correlationID, &causationID, &groupID, roleID, roleAdditionalContent))
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -1451,7 +1451,7 @@ func (s *CommandService) createMember(ctx context.Context, c *change.CreateMembe
 
 	command := commands.NewCommand(commands.CommandTypeCreateMember, callingMemberID, commands.NewCommandCreateMember(c, passwordHash))
 
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, member.ID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, member.ID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	events = events.AddEvent(eventstore.NewEventMemberCreated(&correlationID, &causationID, &groupID, member))
@@ -1466,7 +1466,7 @@ func (s *CommandService) createMember(ctx context.Context, c *change.CreateMembe
 		events = events.AddEvent(eventstore.NewEventMemberMatchUIDSet(&correlationID, &causationID, &groupID, member.ID, c.MatchUID))
 	}
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, member.ID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, member.ID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -1621,7 +1621,7 @@ func (s *CommandService) UpdateMember(ctx context.Context, c *change.UpdateMembe
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeUpdateMember, callingMember.ID, commands.NewCommandUpdateMember(c))
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, member.ID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, member.ID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	events = events.AddEvent(eventstore.NewEventMemberUpdated(&correlationID, &causationID, &groupID, member))
@@ -1630,7 +1630,7 @@ func (s *CommandService) UpdateMember(ctx context.Context, c *change.UpdateMembe
 		events = events.AddEvent(eventstore.NewEventMemberAvatarSet(&correlationID, &causationID, &groupID, member.ID, avatar))
 	}
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, member.ID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, member.ID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -1693,12 +1693,12 @@ func (s *CommandService) SetMemberPassword(ctx context.Context, memberID util.ID
 
 	command := commands.NewCommand(commands.CommandTypeSetMemberPassword, callingMember.ID, commands.SetMemberPassword{MemberID: memberID, PasswordHash: passwordHash})
 
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, memberID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, memberID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	events = events.AddEvent(eventstore.NewEventMemberPasswordSet(&correlationID, &causationID, &groupID, memberID, passwordHash))
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, memberID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, memberID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, err
@@ -1763,12 +1763,12 @@ func (s *CommandService) setMemberMatchUID(ctx context.Context, memberID util.ID
 	// NOTE(sgotti) Changing a password doesn't require a new timeline since there's no history of previous password, the command will have an empty timeline
 	command := commands.NewCommand(commands.CommandTypeSetMemberMatchUID, callingMemberID, commands.SetMemberMatchUID{MemberID: memberID, MatchUID: matchUID})
 
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, memberID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, memberID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	events = events.AddEvent(eventstore.NewEventMemberMatchUIDSet(&correlationID, &causationID, &groupID, memberID, matchUID))
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, memberID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.MemberAggregate, memberID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, err
@@ -1856,12 +1856,12 @@ func (s *CommandService) CreateTension(ctx context.Context, c *change.CreateTens
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeCreateTension, callingMember.ID, commands.NewCommandCreateTension(c))
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.TensionAggregate, tension.ID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.TensionAggregate, tension.ID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	events = events.AddEvent(eventstore.NewEventTensionCreated(&correlationID, &causationID, &groupID, tension, callingMember.ID, c.RoleID))
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.TensionAggregate, tension.ID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.TensionAggregate, tension.ID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -1996,7 +1996,7 @@ func (s *CommandService) UpdateTension(ctx context.Context, c *change.UpdateTens
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeUpdateTension, callingMember.ID, commands.NewCommandUpdateTension(c))
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.TensionAggregate, tension.ID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.TensionAggregate, tension.ID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	if roleChanged {
@@ -2005,7 +2005,7 @@ func (s *CommandService) UpdateTension(ctx context.Context, c *change.UpdateTens
 
 	events = events.AddEvent(eventstore.NewEventTensionUpdated(&correlationID, &causationID, &groupID, tension))
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.TensionAggregate, tension.ID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.TensionAggregate, tension.ID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -2070,12 +2070,12 @@ func (s *CommandService) CloseTension(ctx context.Context, c *change.CloseTensio
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeCloseTension, callingMember.ID, commands.NewCommandCloseTension(c))
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.TensionAggregate, tension.ID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.TensionAggregate, tension.ID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	events = events.AddEvent(eventstore.NewEventTensionClosed(&correlationID, &causationID, &groupID, tension.ID, c.Reason))
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.TensionAggregate, tension.ID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.TensionAggregate, tension.ID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -2137,12 +2137,12 @@ func (s *CommandService) CircleAddDirectMember(ctx context.Context, roleID util.
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeCircleAddDirectMember, callingMember.ID, &commands.CircleAddDirectMember{RoleID: roleID, MemberID: memberID})
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	events = events.AddEvent(eventstore.NewEventCircleDirectMemberAdded(&correlationID, &causationID, &groupID, roleID, memberID))
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -2207,12 +2207,12 @@ func (s *CommandService) CircleRemoveDirectMember(ctx context.Context, roleID ut
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeCircleRemoveDirectMember, callingMember.ID, &commands.CircleRemoveDirectMember{RoleID: roleID, MemberID: memberID})
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	events = events.AddEvent(eventstore.NewEventCircleDirectMemberRemoved(&correlationID, &causationID, &groupID, roleID, memberID))
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -2306,7 +2306,7 @@ func (s *CommandService) CircleSetLeadLinkMember(ctx context.Context, roleID, me
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeCircleSetLeadLinkMember, callingMember.ID, &commands.CircleSetLeadLinkMember{RoleID: roleID, MemberID: memberID})
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	// Remove previous lead link
@@ -2320,7 +2320,7 @@ func (s *CommandService) CircleSetLeadLinkMember(ctx context.Context, roleID, me
 
 	events = events.AddEvent(eventstore.NewEventCircleLeadLinkMemberSet(&correlationID, &causationID, &groupID, roleID, leadLinkRole.ID, memberID))
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -2434,7 +2434,7 @@ func (s *CommandService) CircleUnsetLeadLinkMember(ctx context.Context, roleID u
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeCircleUnsetLeadLinkMember, callingMember.ID, &commands.CircleUnsetLeadLinkMember{RoleID: roleID})
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	es, err := s.circleUnsetLeadLinkMember(correlationID, causationID, groupID, curTl, role.ID)
@@ -2443,7 +2443,7 @@ func (s *CommandService) CircleUnsetLeadLinkMember(ctx context.Context, roleID u
 	}
 	events = events.AddEvents(es)
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -2516,7 +2516,7 @@ func (s *CommandService) CircleSetCoreRoleMember(ctx context.Context, roleType m
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeCircleSetCoreRoleMember, callingMember.ID, &commands.CircleSetCoreRoleMember{RoleType: roleType, RoleID: roleID, MemberID: memberID, ElectionExpiration: electionExpiration})
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	// Remove previous core role member
@@ -2526,7 +2526,7 @@ func (s *CommandService) CircleSetCoreRoleMember(ctx context.Context, roleType m
 
 	events = events.AddEvent(eventstore.NewEventCircleCoreRoleMemberSet(&correlationID, &causationID, &groupID, role.ID, coreRole.ID, memberID, roleType, electionExpiration))
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -2620,7 +2620,7 @@ func (s *CommandService) CircleUnsetCoreRoleMember(ctx context.Context, roleType
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeCircleUnsetCoreRoleMember, callingMember.ID, &commands.CircleUnsetCoreRoleMember{RoleType: roleType, RoleID: roleID})
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	es, err := s.circleUnsetCoreRoleMember(correlationID, causationID, groupID, curTl, roleType, role.ID)
@@ -2629,7 +2629,7 @@ func (s *CommandService) CircleUnsetCoreRoleMember(ctx context.Context, roleType
 	}
 	events = events.AddEvents(es)
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -2714,12 +2714,12 @@ func (s *CommandService) RoleAddMember(ctx context.Context, roleID util.ID, memb
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeRoleAddMember, callingMember.ID, &commands.RoleAddMember{RoleID: roleID, MemberID: memberID, Focus: focus, NoCoreMember: noCoreMember})
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	events = events.AddEvent(eventstore.NewEventRoleMemberAdded(&correlationID, &causationID, &groupID, roleID, memberID, focus, noCoreMember))
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -2791,12 +2791,12 @@ func (s *CommandService) RoleRemoveMember(ctx context.Context, roleID util.ID, m
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeRoleRemoveMember, callingMember.ID, &commands.RoleRemoveMember{RoleID: roleID, MemberID: memberID})
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	events = events.AddEvent(eventstore.NewEventRoleMemberRemoved(&correlationID, &causationID, &groupID, roleID, memberID))
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -2877,12 +2877,12 @@ func (s *CommandService) RoleUpdateMember(ctx context.Context, roleID util.ID, m
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeRoleUpdateMember, callingMember.ID, &commands.RoleUpdateMember{RoleID: roleID, MemberID: memberID, Focus: focus, NoCoreMember: noCoreMember})
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	events = events.AddEvent(eventstore.NewEventRoleMemberUpdated(&correlationID, &causationID, &groupID, roleID, memberID, focus, noCoreMember))
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return nil, util.NilID, err
@@ -2937,7 +2937,7 @@ func (s *CommandService) SetupRootRole() (util.ID, error) {
 	events := eventstore.NewEvents()
 
 	command := commands.NewCommand(commands.CommandTypeSetupRootRole, util.NilID, &commands.SetupRootRole{})
-	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command)
+	commandEvent := eventstore.NewEventCommandExecuted(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command)
 	events = events.AddEvent(commandEvent)
 
 	role.ID = s.uidGenerator.UUID("RootRole")
@@ -2950,7 +2950,7 @@ func (s *CommandService) SetupRootRole() (util.ID, error) {
 	}
 	events = events.AddEvents(es)
 
-	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID, command))
+	events = events.AddEvent(eventstore.NewEventCommandExecutionFinished(&correlationID, &causationID, &groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), command))
 
 	if err := s.writeEvents(events); err != nil {
 		return util.NilID, err

--- a/db/migration.go
+++ b/db/migration.go
@@ -98,10 +98,10 @@ var migrations = []migration{
 	{
 		stmts: []string{
 			// === EventStore ===
-			`create table event (id uuid, sequencenumber bigint, eventtype varchar not null, aggregatetype varchar, aggregateid uuid, timestamp timestamptz not null, version bigint, correlationid uuid, causationid uuid, groupid uuid, data bytea,
+			`create table event (id uuid not null, sequencenumber bigint, eventtype varchar not null, aggregatetype varchar not null, aggregateid varchar not null, timestamp timestamptz not null, version bigint, correlationid uuid, causationid uuid, groupid uuid, data bytea,
 		PRIMARY KEY (sequencenumber))`,
 			// stores the latest version for every aggregate
-			"create table aggregateversion (aggregatetype varchar, aggregateid uuid, version bigint, PRIMARY KEY(aggregateid, version))",
+			"create table aggregateversion (aggregatetype varchar not null, aggregateid varchar not null, version bigint not null, PRIMARY KEY(aggregateid, version))",
 
 			// === ReadDB ===
 
@@ -112,7 +112,7 @@ var migrations = []migration{
 			// we can end with different "events" happening at the same time
 			// (with millisecond precision for postgres), so timestamp cannot be
 			// unique.
-			"create table timeline (timestamp timestamptz not null, groupid uuid, aggregatetype varchar, aggregateid uuid, PRIMARY KEY(groupid))",
+			"create table timeline (timestamp timestamptz not null, groupid uuid not null, aggregatetype varchar not null, aggregateid varchar not null, PRIMARY KEY(groupid))",
 			"create index timeline_ts on timeline(timestamp)",
 			"create index timeline_aggregatetype on timeline(aggregatetype)",
 			"create index timeline_aggregateid on timeline(aggregateid)",

--- a/eventstore/event.go
+++ b/eventstore/event.go
@@ -23,7 +23,7 @@ type Event struct {
 	SequenceNumber int64   // Global event sequence
 	EventType      EventType
 	AggregateType  AggregateType
-	AggregateID    util.ID
+	AggregateID    string
 	Timestamp      time.Time
 	Version        int64    // Aggregate Version. Increased for every event emitted by a specific aggregate.
 	CorrelationID  *util.ID // ID correlating this event with other events
@@ -37,7 +37,7 @@ type EventRaw struct {
 	SequenceNumber int64   // Global event sequence
 	EventType      EventType
 	AggregateType  AggregateType
-	AggregateID    util.ID
+	AggregateID    string
 	Timestamp      time.Time
 	Version        int64    // Aggregate Version. Increased for every event emitted by a specific aggregate.
 	CorrelationID  *util.ID // ID correlating this event with other events
@@ -89,7 +89,7 @@ func (es Events) AddEvents(events Events) Events {
 
 type AggregateVersion struct {
 	AggregateType AggregateType
-	AggregateID   util.ID
+	AggregateID   string
 	Version       int64 // Aggregate Version. Increased for every event emitted by a specific aggregate.
 }
 
@@ -241,7 +241,7 @@ func GetEventDataType(eventType EventType) interface{} {
 	}
 }
 
-func NewEvent(correlationID, causationID, groupID *util.ID, eventType EventType, aggregateType AggregateType, aggregateID util.ID, data interface{}) *Event {
+func NewEvent(correlationID, causationID, groupID *util.ID, eventType EventType, aggregateType AggregateType, aggregateID string, data interface{}) *Event {
 	uuid := util.NewFromUUID(uuid.NewV4())
 	log.Debugf("generated event UUID: %s", uuid)
 	return &Event{
@@ -260,7 +260,7 @@ type EventCommandExecuted struct {
 	Command *commands.Command
 }
 
-func NewEventCommandExecuted(correlationID, causationID, groupID *util.ID, aggregateType AggregateType, aggregateID util.ID, command *commands.Command) *Event {
+func NewEventCommandExecuted(correlationID, causationID, groupID *util.ID, aggregateType AggregateType, aggregateID string, command *commands.Command) *Event {
 	return NewEvent(correlationID,
 		causationID,
 		groupID,
@@ -276,7 +276,7 @@ func NewEventCommandExecuted(correlationID, causationID, groupID *util.ID, aggre
 type EventCommandExecutionFinished struct {
 }
 
-func NewEventCommandExecutionFinished(correlationID, causationID, groupID *util.ID, aggregateType AggregateType, aggregateID util.ID, result interface{}) *Event {
+func NewEventCommandExecutionFinished(correlationID, causationID, groupID *util.ID, aggregateType AggregateType, aggregateID string, result interface{}) *Event {
 	return NewEvent(correlationID,
 		causationID,
 		groupID,
@@ -298,7 +298,7 @@ type EventRoleCreated struct {
 func NewEventRoleCreated(correlationID, causationID, groupID *util.ID, role *models.Role, parentRoleID *util.ID) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeRoleCreated,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventRoleCreated{
 			RoleID:       role.ID,
 			RoleType:     role.RoleType,
@@ -319,7 +319,7 @@ type EventRoleUpdated struct {
 func NewEventRoleUpdated(correlationID, causationID, groupID *util.ID, role *models.Role) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeRoleUpdated,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventRoleUpdated{
 			RoleID:   role.ID,
 			RoleType: role.RoleType,
@@ -336,7 +336,7 @@ type EventRoleDeleted struct {
 func NewEventRoleDeleted(correlationID, causationID, groupID *util.ID, roleID util.ID) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeRoleDeleted,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventRoleDeleted{
 			RoleID: roleID,
 		},
@@ -351,7 +351,7 @@ type EventRoleChangedParent struct {
 func NewEventRoleChangedParent(correlationID, causationID, groupID *util.ID, roleID util.ID, parentRoleID *util.ID) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeRoleChangedParent,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventRoleChangedParent{
 			RoleID:       roleID,
 			ParentRoleID: parentRoleID,
@@ -368,7 +368,7 @@ type EventRoleDomainCreated struct {
 func NewEventRoleDomainCreated(correlationID, causationID, groupID *util.ID, roleID util.ID, domain *models.Domain) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeRoleDomainCreated,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventRoleDomainCreated{
 			DomainID:    domain.ID,
 			RoleID:      roleID,
@@ -386,7 +386,7 @@ type EventRoleDomainUpdated struct {
 func NewEventRoleDomainUpdated(correlationID, causationID, groupID *util.ID, roleID util.ID, domain *models.Domain) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeRoleDomainUpdated,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventRoleDomainUpdated{
 			DomainID:    domain.ID,
 			RoleID:      roleID,
@@ -403,7 +403,7 @@ type EventRoleDomainDeleted struct {
 func NewEventRoleDomainDeleted(correlationID, causationID, groupID *util.ID, roleID, domainID util.ID) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeRoleDomainDeleted,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventRoleDomainDeleted{
 			DomainID: domainID,
 			RoleID:   roleID,
@@ -420,7 +420,7 @@ type EventRoleAccountabilityCreated struct {
 func NewEventRoleAccountabilityCreated(correlationID, causationID, groupID *util.ID, roleID util.ID, accountability *models.Accountability) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeRoleAccountabilityCreated,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventRoleAccountabilityCreated{
 			AccountabilityID: accountability.ID,
 			RoleID:           roleID,
@@ -438,7 +438,7 @@ type EventRoleAccountabilityUpdated struct {
 func NewEventRoleAccountabilityUpdated(correlationID, causationID, groupID *util.ID, roleID util.ID, accountability *models.Accountability) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeRoleAccountabilityUpdated,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventRoleAccountabilityUpdated{
 			AccountabilityID: accountability.ID,
 			RoleID:           roleID,
@@ -455,7 +455,7 @@ type EventRoleAccountabilityDeleted struct {
 func NewEventRoleAccountabilityDeleted(correlationID, causationID, groupID *util.ID, roleID, accountability util.ID) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeRoleAccountabilityDeleted,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventRoleAccountabilityDeleted{
 			AccountabilityID: accountability,
 			RoleID:           roleID,
@@ -471,7 +471,7 @@ type EventRoleAdditionalContentSet struct {
 func NewEventRoleAdditionalContentSet(correlationID, causationID, groupID *util.ID, roleID util.ID, roleAdditionalContent *models.RoleAdditionalContent) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeRoleAdditionalContentSet,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventRoleAdditionalContentSet{
 			RoleID:  roleID,
 			Content: roleAdditionalContent.Content,
@@ -489,7 +489,7 @@ type EventRoleMemberAdded struct {
 func NewEventRoleMemberAdded(correlationID, causationID, groupID *util.ID, roleID, memberID util.ID, focus *string, noCoreMember bool) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeRoleMemberAdded,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventRoleMemberAdded{
 			RoleID:       roleID,
 			MemberID:     memberID,
@@ -509,7 +509,7 @@ type EventRoleMemberUpdated struct {
 func NewEventRoleMemberUpdated(correlationID, causationID, groupID *util.ID, roleID, memberID util.ID, focus *string, noCoreMember bool) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeRoleMemberUpdated,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventRoleMemberUpdated{
 			RoleID:       roleID,
 			MemberID:     memberID,
@@ -527,7 +527,7 @@ type EventRoleMemberRemoved struct {
 func NewEventRoleMemberRemoved(correlationID, causationID, groupID *util.ID, roleID, memberID util.ID) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeRoleMemberRemoved,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventRoleMemberRemoved{
 			RoleID:   roleID,
 			MemberID: memberID,
@@ -543,7 +543,7 @@ type EventCircleDirectMemberAdded struct {
 func NewEventCircleDirectMemberAdded(correlationID, causationID, groupID *util.ID, roleID, memberID util.ID) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeCircleDirectMemberAdded,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventCircleDirectMemberAdded{
 			RoleID:   roleID,
 			MemberID: memberID,
@@ -559,7 +559,7 @@ type EventCircleDirectMemberRemoved struct {
 func NewEventCircleDirectMemberRemoved(correlationID, causationID, groupID *util.ID, roleID, memberID util.ID) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeCircleDirectMemberRemoved,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventCircleDirectMemberRemoved{
 			RoleID:   roleID,
 			MemberID: memberID,
@@ -579,7 +579,7 @@ type EventCircleLeadLinkMemberSet struct {
 func NewEventCircleLeadLinkMemberSet(correlationID, causationID, groupID *util.ID, roleID, leadLinkRoleID, memberID util.ID) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeCircleLeadLinkMemberSet,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventCircleLeadLinkMemberSet{
 			RoleID:         roleID,
 			LeadLinkRoleID: leadLinkRoleID,
@@ -600,7 +600,7 @@ type EventCircleLeadLinkMemberUnset struct {
 func NewEventCircleLeadLinkMemberUnset(correlationID, causationID, groupID *util.ID, roleID, leadLinkRoleID, memberID util.ID) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeCircleLeadLinkMemberUnset,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventCircleLeadLinkMemberUnset{
 			RoleID:         roleID,
 			LeadLinkRoleID: leadLinkRoleID,
@@ -623,7 +623,7 @@ type EventCircleCoreRoleMemberSet struct {
 func NewEventCircleCoreRoleMemberSet(correlationID, causationID, groupID *util.ID, roleID, coreRoleID, memberID util.ID, roleType models.RoleType, electionExpiration *time.Time) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeCircleCoreRoleMemberSet,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventCircleCoreRoleMemberSet{
 			RoleID:             roleID,
 			RoleType:           roleType,
@@ -647,7 +647,7 @@ type EventCircleCoreRoleMemberUnset struct {
 func NewEventCircleCoreRoleMemberUnset(correlationID, causationID, groupID *util.ID, roleID, coreRoleID, memberID util.ID, roleType models.RoleType) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeCircleCoreRoleMemberUnset,
 		RolesTreeAggregate,
-		RolesTreeAggregateID,
+		RolesTreeAggregateID.String(),
 		&EventCircleCoreRoleMemberUnset{
 			RoleID:     roleID,
 			RoleType:   roleType,
@@ -667,7 +667,7 @@ type EventTensionCreated struct {
 func NewEventTensionCreated(correlationID, causationID, groupID *util.ID, tension *models.Tension, memberID util.ID, roleID *util.ID) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeTensionCreated,
 		TensionAggregate,
-		tension.ID,
+		tension.ID.String(),
 		&EventTensionCreated{
 			Title:       tension.Title,
 			Description: tension.Description,
@@ -685,7 +685,7 @@ type EventTensionUpdated struct {
 func NewEventTensionUpdated(correlationID, causationID, groupID *util.ID, tension *models.Tension) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeTensionUpdated,
 		TensionAggregate,
-		tension.ID,
+		tension.ID.String(),
 		&EventTensionUpdated{
 			Title:       tension.Title,
 			Description: tension.Description,
@@ -701,7 +701,7 @@ type EventTensionRoleChanged struct {
 func NewEventTensionRoleChanged(correlationID, causationID, groupID *util.ID, tensionID util.ID, prevRoleID, roleID *util.ID) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeTensionRoleChanged,
 		TensionAggregate,
-		tensionID,
+		tensionID.String(),
 		&EventTensionRoleChanged{
 			PrevRoleID: prevRoleID,
 			RoleID:     roleID,
@@ -716,7 +716,7 @@ type EventTensionClosed struct {
 func NewEventTensionClosed(correlationID, causationID, groupID *util.ID, tensionID util.ID, reason string) *Event {
 	return NewEvent(correlationID, causationID, groupID, EventTypeTensionClosed,
 		TensionAggregate,
-		tensionID,
+		tensionID.String(),
 		&EventTensionClosed{
 			Reason: reason,
 		},
@@ -735,7 +735,7 @@ func NewEventMemberCreated(correlationID, causationID, groupID *util.ID, member 
 		groupID,
 		EventTypeMemberCreated,
 		MemberAggregate,
-		member.ID,
+		member.ID.String(),
 		&EventMemberCreated{
 			IsAdmin:  member.IsAdmin,
 			UserName: member.UserName,
@@ -757,7 +757,7 @@ func NewEventMemberUpdated(correlationID, causationID, groupID *util.ID, member 
 		groupID,
 		EventTypeMemberUpdated,
 		MemberAggregate,
-		member.ID,
+		member.ID.String(),
 		&EventMemberUpdated{
 			IsAdmin:  member.IsAdmin,
 			UserName: member.UserName,
@@ -776,7 +776,7 @@ func NewEventMemberPasswordSet(correlationID, causationID, groupID *util.ID, mem
 		groupID,
 		EventTypeMemberPasswordSet,
 		MemberAggregate,
-		memberID,
+		memberID.String(),
 		&EventMemberPasswordSet{
 			PasswordHash: passwordHash,
 		},
@@ -792,7 +792,7 @@ func NewEventMemberAvatarSet(correlationID, causationID, groupID *util.ID, membe
 		groupID,
 		EventTypeMemberAvatarSet,
 		MemberAggregate,
-		memberID,
+		memberID.String(),
 		&EventMemberAvatarSet{
 			Image: image,
 		},
@@ -808,7 +808,7 @@ func NewEventMemberMatchUIDSet(correlationID, causationID, groupID *util.ID, mem
 		groupID,
 		EventTypeMemberMatchUIDSet,
 		MemberAggregate,
-		memberID,
+		memberID.String(),
 		&EventMemberMatchUIDSet{
 			MatchUID: matchUID,
 		},

--- a/eventstore/eventstore.go
+++ b/eventstore/eventstore.go
@@ -174,9 +174,9 @@ func (s *EventStore) LastSequenceNumber() (int64, error) {
 }
 
 func (s *EventStore) WriteEvents(events Events) (int64, error) {
-	aggregatesIDsMap := map[util.ID]struct{}{}
-	aggregatesIDs := []util.ID{}
-	versions := map[util.ID]*AggregateVersion{}
+	aggregatesIDsMap := map[string]struct{}{}
+	aggregatesIDs := []string{}
+	versions := map[string]*AggregateVersion{}
 	// get the aggregates versions
 	for _, e := range events {
 		aggregatesIDsMap[e.AggregateID] = struct{}{}
@@ -247,7 +247,7 @@ func (s *EventStore) WriteEvents(events Events) (int64, error) {
 }
 
 func (s *EventStore) RestoreEvents(events Events) (int64, error) {
-	versions := map[util.ID]*AggregateVersion{}
+	versions := map[string]*AggregateVersion{}
 
 	lastSequenceNumber, err := s.LastSequenceNumber()
 	if err != nil {

--- a/eventstore/eventstore_test.go
+++ b/eventstore/eventstore_test.go
@@ -7,25 +7,22 @@ import (
 	"testing"
 
 	"github.com/sorintlab/sircles/db"
-	"github.com/sorintlab/sircles/util"
-
-	"github.com/satori/go.uuid"
 )
 
 func TestWriteEvents(t *testing.T) {
 	events1 := Events{
 		&Event{
-			AggregateID:   util.NewFromUUID(uuid.FromStringOrNil("b1399c23-5b50-4c72-b803-804efaba0cb1")),
+			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
 			AggregateType: RolesTreeAggregate,
 			EventType:     EventTypeCommandExecuted,
 		},
 		&Event{
-			AggregateID:   util.NewFromUUID(uuid.FromStringOrNil("b1399c23-5b50-4c72-b803-804efaba0cb1")),
+			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
 			AggregateType: RolesTreeAggregate,
 			EventType:     EventTypeRoleCreated,
 		},
 		&Event{
-			AggregateID:   util.NewFromUUID(uuid.FromStringOrNil("b1399c23-5b50-4c72-b803-804efaba0cb1")),
+			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
 			AggregateType: RolesTreeAggregate,
 			EventType:     EventTypeRoleMemberAdded,
 		},
@@ -42,17 +39,17 @@ func TestWriteEvents(t *testing.T) {
 
 	events2 := Events{
 		&Event{
-			AggregateID:   util.NewFromUUID(uuid.FromStringOrNil("b1399c23-5b50-4c72-b803-804efaba0cb1")),
+			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
 			AggregateType: RolesTreeAggregate,
 			EventType:     EventTypeCommandExecuted,
 		},
 		&Event{
-			AggregateID:   util.NewFromUUID(uuid.FromStringOrNil("b1399c23-5b50-4c72-b803-804efaba0cb1")),
+			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
 			AggregateType: RolesTreeAggregate,
 			EventType:     EventTypeRoleCreated,
 		},
 		&Event{
-			AggregateID:   util.NewFromUUID(uuid.FromStringOrNil("b1399c23-5b50-4c72-b803-804efaba0cb1")),
+			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
 			AggregateType: RolesTreeAggregate,
 			EventType:     EventTypeRoleChangedParent,
 		},
@@ -120,17 +117,17 @@ func TestWriteEvents(t *testing.T) {
 func TestRestoreEvents(t *testing.T) {
 	events1 := Events{
 		&Event{
-			AggregateID:   util.NewFromUUID(uuid.FromStringOrNil("b1399c23-5b50-4c72-b803-804efaba0cb1")),
+			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
 			AggregateType: RolesTreeAggregate,
 			EventType:     EventTypeCommandExecuted,
 		},
 		&Event{
-			AggregateID:   util.NewFromUUID(uuid.FromStringOrNil("b1399c23-5b50-4c72-b803-804efaba0cb1")),
+			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
 			AggregateType: RolesTreeAggregate,
 			EventType:     EventTypeRoleCreated,
 		},
 		&Event{
-			AggregateID:   util.NewFromUUID(uuid.FromStringOrNil("b1399c23-5b50-4c72-b803-804efaba0cb1")),
+			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
 			AggregateType: RolesTreeAggregate,
 			EventType:     EventTypeRoleMemberAdded,
 		},
@@ -147,17 +144,17 @@ func TestRestoreEvents(t *testing.T) {
 
 	events2 := Events{
 		&Event{
-			AggregateID:   util.NewFromUUID(uuid.FromStringOrNil("b1399c23-5b50-4c72-b803-804efaba0cb1")),
+			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
 			AggregateType: RolesTreeAggregate,
 			EventType:     EventTypeCommandExecuted,
 		},
 		&Event{
-			AggregateID:   util.NewFromUUID(uuid.FromStringOrNil("b1399c23-5b50-4c72-b803-804efaba0cb1")),
+			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
 			AggregateType: RolesTreeAggregate,
 			EventType:     EventTypeRoleCreated,
 		},
 		&Event{
-			AggregateID:   util.NewFromUUID(uuid.FromStringOrNil("b1399c23-5b50-4c72-b803-804efaba0cb1")),
+			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
 			AggregateType: RolesTreeAggregate,
 			EventType:     EventTypeRoleChangedParent,
 		},

--- a/search/search.go
+++ b/search/search.go
@@ -304,10 +304,18 @@ func (s *SearchEngine) HandlEvent(event *eventstore.Event) error {
 	case eventstore.EventTypeTensionClosed:
 
 	case eventstore.EventTypeMemberCreated:
-		reindexMembers = append(reindexMembers, event.AggregateID)
+		memberID, err := util.IDFromString(event.AggregateID)
+		if err != nil {
+			return err
+		}
+		reindexMembers = append(reindexMembers, memberID)
 
 	case eventstore.EventTypeMemberUpdated:
-		reindexMembers = append(reindexMembers, event.AggregateID)
+		memberID, err := util.IDFromString(event.AggregateID)
+		if err != nil {
+			return err
+		}
+		reindexMembers = append(reindexMembers, memberID)
 
 	case eventstore.EventTypeMemberPasswordSet:
 

--- a/util/id.go
+++ b/util/id.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"github.com/pkg/errors"
 	"github.com/satori/go.uuid"
 )
 
@@ -12,6 +13,14 @@ var NilID = ID{uuid.Nil}
 
 func NewFromUUID(u uuid.UUID) ID {
 	return ID{UUID: u}
+}
+
+func IDFromString(us string) (ID, error) {
+	u, err := uuid.FromString(us)
+	if err != nil {
+		return NilID, errors.WithStack(err)
+	}
+	return ID{UUID: u}, nil
 }
 
 type IDs []ID


### PR DESCRIPTION
In future we'll need aggregateid in other forms than uuid (i.e. string names).