### PR TITLE
eventstore: initial concurrent writes implementation

### DIFF
--- a/api/graphql/schema_test.go
+++ b/api/graphql/schema_test.go
@@ -532,6 +532,12 @@ func runTests(t *testing.T, initFunc initFunc, tests []*Test, parallel bool) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	if parallel {
+		// when running concurrent tests use the default uid generator or the
+		// same uuid will be generated for aggregates with the same properties
+		uidGenerator = &common.DefaultUidGenerator{}
+	}
+
 	if !parallel {
 		for i, test := range tests {
 			t.Run(strconv.Itoa(i+1), func(t *testing.T) {
@@ -2885,7 +2891,7 @@ func TestConcurrentChangeRolesTree(t *testing.T) {
 				}
 			}
 			`,
-			Error: fmt.Errorf("graphql: failed to execute query: pq: could not serialize access due to read/write dependencies among transactions"),
+			Error: fmt.Errorf(`graphql: failed to execute query: pq: duplicate key value violates unique constraint "event_aggregatetype_aggregateid_version_key"`),
 		},
 	}, true)
 }

--- a/cmd/sircles/restore.go
+++ b/cmd/sircles/restore.go
@@ -137,13 +137,8 @@ func applyEvents(db *db.DB, events eventstore.Events) error {
 	if err != nil {
 		return err
 	}
-	sequenceNumber := events[len(events)-1].SequenceNumber
-	curSequenceNumber, err := es.RestoreEvents(events)
-	if err != nil {
+	if err := es.RestoreEvents(events); err != nil {
 		return err
-	}
-	if sequenceNumber != curSequenceNumber {
-		return errors.Errorf("expected sequence number: %d != writed event sequence number: %d", sequenceNumber, curSequenceNumber)
 	}
 	if err := readDB.ApplyEvents(events); err != nil {
 		return err

--- a/db/db.go
+++ b/db/db.go
@@ -46,6 +46,10 @@ var (
 	dbDataPostgres = dbData{
 		t:                 Postgres,
 		supportsTimezones: true,
+		queryReplacers: []replacer{
+			// Remove sqlite3 only statements
+			{regexp.MustCompile(`--SQLITE3\n.*`), ""},
+		},
 	}
 
 	dbDataSQLite3 = dbData{
@@ -61,6 +65,10 @@ var (
 			{matchLiteral("timestamptz"), "timestamp"},
 			// convert now to the max precision time available with sqlite3
 			{regexp.MustCompile(`\bnow\(\)`), "strftime('%Y-%m-%d %H:%M:%f', 'now')"},
+			{regexp.MustCompile(`select pg_advisory_xact_lock\(.*`), "select 1"},
+			{regexp.MustCompile(`notify\s+.*`), "select 1"},
+			// Remove postgres only statements
+			{regexp.MustCompile(`--POSTGRES\n.*`), ""},
 		},
 	}
 

--- a/db/migration.go
+++ b/db/migration.go
@@ -98,8 +98,13 @@ var migrations = []migration{
 	{
 		stmts: []string{
 			// === EventStore ===
-			`create table event (id uuid not null, sequencenumber bigint, eventtype varchar not null, aggregatetype varchar not null, aggregateid varchar not null, timestamp timestamptz not null, version bigint, correlationid uuid, causationid uuid, groupid uuid, data bytea,
-		PRIMARY KEY (sequencenumber))`,
+			`--POSTGRES
+             create table event (id uuid not null, sequencenumber bigserial, eventtype varchar not null, aggregatetype varchar not null, aggregateid varchar not null, timestamp timestamptz not null, version bigint not null, correlationid uuid, causationid uuid, groupid uuid, data bytea, PRIMARY KEY (sequencenumber), UNIQUE (aggregatetype, aggregateid, version))`,
+			`--SQLITE3
+             create table event (id uuid not null, sequencenumber INTEGER PRIMARY KEY AUTOINCREMENT, eventtype varchar not null, aggregatetype varchar not null, aggregateid varchar not null, timestamp timestamptz not null, version bigint not null, correlationid uuid, causationid uuid, groupid uuid, data bytea, UNIQUE (aggregatetype, aggregateid, version))`,
+			"create index event_aggregateid_version on event(aggregateid, version)",
+			"create index event_aggregatetype on event(aggregatetype)",
+
 			// stores the latest version for every aggregate
 			"create table aggregateversion (aggregatetype varchar not null, aggregateid varchar not null, version bigint not null, PRIMARY KEY(aggregateid, version))",
 

--- a/eventstore/eventstore_test.go
+++ b/eventstore/eventstore_test.go
@@ -1,6 +1,7 @@
 package eventstore
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -9,10 +10,10 @@ import (
 	"github.com/sorintlab/sircles/db"
 )
 
-func TestWriteEvents(t *testing.T) {
-	events1 := Events{
+func TestWriteEventsDifferentAggregateID(t *testing.T) {
+	events := Events{
 		&Event{
-			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
+			AggregateID:   "65c4dce5-2935-46eb-a71e-3ea1cb4b970c",
 			AggregateType: RolesTreeAggregate,
 			EventType:     EventTypeCommandExecuted,
 		},
@@ -28,40 +29,13 @@ func TestWriteEvents(t *testing.T) {
 		},
 	}
 
-	expectedVersions := []int64{
-		1,
-		2,
-		3,
-		4,
-		5,
-		6,
-	}
-
-	events2 := Events{
-		&Event{
-			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
-			AggregateType: RolesTreeAggregate,
-			EventType:     EventTypeCommandExecuted,
-		},
-		&Event{
-			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
-			AggregateType: RolesTreeAggregate,
-			EventType:     EventTypeRoleCreated,
-		},
-		&Event{
-			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
-			AggregateType: RolesTreeAggregate,
-			EventType:     EventTypeRoleChangedParent,
-		},
-	}
-
 	tmpDir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatalf("ioutil.TempDir(%q, %q) got error %q", "", "", err)
 	}
 	defer os.RemoveAll(tmpDir)
 
-	dbpath := filepath.Join(tmpDir, "db.ql")
+	dbpath := filepath.Join(tmpDir, "db")
 
 	db, err := db.NewDB("sqlite3", dbpath)
 	if err != nil {
@@ -75,38 +49,16 @@ func TestWriteEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
 	es := NewEventStore(tx)
 
-	seq, err := es.WriteEvents(events1)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	expectedSeq := int64(len(events1))
-	if seq != expectedSeq {
-		t.Fatalf("expected event sequence %d, got %d", expectedSeq, seq)
-	}
-
-	seq, err = es.WriteEvents(events2)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	expectedSeq = int64(len(events1) + len(events2))
-	if seq != expectedSeq {
-		t.Fatalf("expected event sequence %d, got %d", expectedSeq, seq)
-	}
-
-	writtenEvents, err := es.GetEvents(0, 1000)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	for i, expectedVersion := range expectedVersions {
-		if writtenEvents[i].Version != expectedVersion {
-			t.Fatalf("expected event version %d, got %d for event seq %d", expectedVersion, writtenEvents[i].Version, seq)
+	expectedErr := "events have different aggregate id"
+	if err := es.WriteEvents(events, 0); err != nil {
+		if err.Error() != expectedErr {
+			t.Fatalf("expected error: %v, got: %v", expectedErr, err)
 		}
+	} else {
+		t.Fatalf("expected error: %v, got no error", expectedErr)
+
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -114,8 +66,8 @@ func TestWriteEvents(t *testing.T) {
 	}
 }
 
-func TestRestoreEvents(t *testing.T) {
-	events1 := Events{
+func TestWriteEvents(t *testing.T) {
+	events := Events{
 		&Event{
 			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
 			AggregateType: RolesTreeAggregate,
@@ -142,7 +94,82 @@ func TestRestoreEvents(t *testing.T) {
 		6,
 	}
 
-	events2 := Events{
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("ioutil.TempDir(%q, %q) got error %q", "", "", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbpath := filepath.Join(tmpDir, "db")
+
+	db, err := db.NewDB("sqlite3", dbpath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tx, err := db.NewTx()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	es := NewEventStore(tx)
+
+	if err := es.WriteEvents(events, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	writtenEvents, err := es.GetEvents(0, 1000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedSeq := int64(len(events))
+	seq := writtenEvents[len(writtenEvents)-1].SequenceNumber
+	if seq != expectedSeq {
+		t.Fatalf("expected event sequence %d, got %d", expectedSeq, seq)
+	}
+
+	if err := es.WriteEvents(events, 3); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	writtenEvents, err = es.GetEvents(0, 1000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedSeq = int64(len(events) * 2)
+	seq = writtenEvents[len(writtenEvents)-1].SequenceNumber
+	if seq != expectedSeq {
+		t.Fatalf("expected event sequence %d, got %d", expectedSeq, seq)
+	}
+
+	for i, expectedVersion := range expectedVersions {
+		if writtenEvents[i].Version != expectedVersion {
+			t.Fatalf("expected event version %d, got %d for event seq %d", expectedVersion, writtenEvents[i].Version, writtenEvents[i].SequenceNumber)
+		}
+	}
+
+	// Write events with different version than the current one
+	expectedErr := fmt.Errorf("current version %d different than provided version %d", 6, 5)
+	if err := es.WriteEvents(events, 5); err == nil {
+		t.Fatalf("expected error %q, got no error", expectedErr)
+	} else {
+		if err.Error() != expectedErr.Error() {
+			t.Fatalf("expected error %q, got error %q", expectedErr, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRestoreEvents(t *testing.T) {
+
+	events1 := Events{
 		&Event{
 			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
 			AggregateType: RolesTreeAggregate,
@@ -156,8 +183,35 @@ func TestRestoreEvents(t *testing.T) {
 		&Event{
 			AggregateID:   "b1399c23-5b50-4c72-b803-804efaba0cb1",
 			AggregateType: RolesTreeAggregate,
-			EventType:     EventTypeRoleChangedParent,
+			EventType:     EventTypeRoleMemberAdded,
 		},
+	}
+
+	events2 := Events{
+		&Event{
+			AggregateID:   "65c4dce5-2935-46eb-a71e-3ea1cb4b970c",
+			AggregateType: RolesTreeAggregate,
+			EventType:     EventTypeCommandExecuted,
+		},
+		&Event{
+			AggregateID:   "65c4dce5-2935-46eb-a71e-3ea1cb4b970c",
+			AggregateType: RolesTreeAggregate,
+			EventType:     EventTypeRoleCreated,
+		},
+		&Event{
+			AggregateID:   "65c4dce5-2935-46eb-a71e-3ea1cb4b970c",
+			AggregateType: RolesTreeAggregate,
+			EventType:     EventTypeRoleMemberAdded,
+		},
+	}
+
+	expectedVersions := []int64{
+		1,
+		2,
+		3,
+		1,
+		2,
+		3,
 	}
 
 	tmpDir, err := ioutil.TempDir("", "")
@@ -166,7 +220,7 @@ func TestRestoreEvents(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	dbpath := filepath.Join(tmpDir, "db1.ql")
+	dbpath := filepath.Join(tmpDir, "db")
 
 	db1, err := db.NewDB("sqlite3", dbpath)
 	if err != nil {
@@ -180,25 +234,17 @@ func TestRestoreEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
 	es := NewEventStore(tx)
 
-	_, err = es.WriteEvents(events1)
-	if err != nil {
+	if err := es.WriteEvents(events1, 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	_, err = es.WriteEvents(events2)
-	if err != nil {
+	if err := es.WriteEvents(events2, 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	writtenEvents, err := es.GetEvents(0, 1000)
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if err = tx.Commit(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -216,11 +262,9 @@ func TestRestoreEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
 	es = NewEventStore(tx)
 
-	seq, err := es.RestoreEvents(writtenEvents)
-	if err != nil {
+	if err := es.RestoreEvents(writtenEvents); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -231,7 +275,7 @@ func TestRestoreEvents(t *testing.T) {
 
 	for i, expectedVersion := range expectedVersions {
 		if restoredEvents[i].Version != expectedVersion {
-			t.Fatalf("expected event version %d, got %d for event seq %d", expectedVersion, restoredEvents[i].Version, seq)
+			t.Fatalf("expected event version %d, got %d for event seq %d", expectedVersion, restoredEvents[i].Version, restoredEvents[i].SequenceNumber)
 		}
 	}
 

--- a/readdb/readdb.go
+++ b/readdb/readdb.go
@@ -3328,16 +3328,6 @@ func (s *DBService) ApplyEvent(event *eventstore.Event) error {
 		panic(errors.Errorf("unhandled event: %s", event.EventType))
 	}
 
-	err = s.tx.Do(func(tx *db.WrappedTx) error {
-		if _, err := tx.Exec("insert into sequencenumber (sequencenumber) values ($1)", event.SequenceNumber); err != nil {
-			return errors.Wrap(err, "failed to save sequencenumber")
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
The eventstore now accepts concurrent writes. They are currently masked by the
serializable isolation level due to the current architecture of a single tx for
every command shared also with the readdb.

This will be relaxed in future when moving to a completely decoupled eventstore
and readdb.

The WriteEvents method requires that all the events are for the same aggregate
and will check that the provided current aggregate version is the current one in
the store to check concurrent writes to the same aggregate.

Since in future there can be many concurrent transactions the above check won't
work with concurrent transactions but it's enforced by an unique constraint on
the aggregate event version that will make the transaction fail.

The global sequence number is now provided by a sequence so it could contain
gaps.

To achieve ordered sequence numbers commits (this won't be possible by default due to
concurrent transactions that could commit sequence numbers out of order) an
advisory lock is taken (for the smaller possible time) before inserting the
events.