### PR TITLE
util: marshal timeline into a string to not lose time precision

### DIFF
--- a/api/graphql/schema.go
+++ b/api/graphql/schema.go
@@ -605,7 +605,7 @@ func unmarshalUID(uid graphql.ID) (util.ID, error) {
 }
 
 type TimeLineCursor struct {
-	TimeLineID    util.TimeLineNumber
+	TimeLineID    string
 	AggregateType string
 	AggregateID   *util.ID
 }
@@ -1371,7 +1371,11 @@ func (r *Resolver) TimeLines(ctx context.Context, args *struct {
 		if err != nil {
 			return nil, err
 		}
-		timeLineID = cursor.TimeLineID
+		tl, err := strconv.ParseInt(cursor.TimeLineID, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		timeLineID = util.TimeLineNumber(tl)
 		aggregateType = cursor.AggregateType
 		aggregateID = cursor.AggregateID
 	}
@@ -1380,7 +1384,11 @@ func (r *Resolver) TimeLines(ctx context.Context, args *struct {
 		if err != nil {
 			return nil, err
 		}
-		timeLineID = cursor.TimeLineID
+		tl, err := strconv.ParseInt(cursor.TimeLineID, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		timeLineID = util.TimeLineNumber(tl)
 		aggregateType = cursor.AggregateType
 		aggregateID = cursor.AggregateID
 	}

--- a/api/graphql/schema_test.go
+++ b/api/graphql/schema_test.go
@@ -774,27 +774,27 @@ func TestTimeLines(t *testing.T) {
 				"timeLines": {
 					"edges": [
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMwOTc5MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoiIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMDk3OTAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509030979000000000
+							"id": "1509030979000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMwOTk4MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoiIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMDk5ODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509030998000000000
+							"id": "1509030998000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDAzMDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoiIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAwMzAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031003000000000
+							"id": "1509031003000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDA4MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoiIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAwODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031008000000000
+							"id": "1509031008000000000"
 						}
 					}
 					],
@@ -820,7 +820,7 @@ func TestTimeLines(t *testing.T) {
 			Variables: `
 			{
 				"first": 4,
-				"after": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDA4MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoiIiwiQWdncmVnYXRlSUQiOm51bGx9"
+				"after": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAwODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0="
 			}
 			`,
 			ExpectedResult: `
@@ -828,27 +828,27 @@ func TestTimeLines(t *testing.T) {
 				"timeLines": {
 					"edges": [
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDEzMDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoiIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAxMzAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031013000000000
+							"id": "1509031013000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDE4MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoiIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAxODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031018000000000
+							"id": "1509031018000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDIzMDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoiIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAyMzAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031023000000000
+							"id": "1509031023000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDI4MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoiIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAyODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031028000000000
+							"id": "1509031028000000000"
 						}
 					}
 					],
@@ -874,7 +874,7 @@ func TestTimeLines(t *testing.T) {
 			Variables: `
 			{
 				"last": 4,
-				"before": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDA4MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoiIiwiQWdncmVnYXRlSUQiOm51bGx9"
+				"before": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAwODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0="
 			}
 			`,
 			ExpectedResult: `
@@ -882,21 +882,21 @@ func TestTimeLines(t *testing.T) {
 				"timeLines": {
 					"edges": [
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDAzMDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoiIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAwMzAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031003000000000
+							"id": "1509031003000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMwOTk4MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoiIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMDk5ODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509030998000000000
+							"id": "1509030998000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMwOTc5MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoiIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMDk3OTAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509030979000000000
+							"id": "1509030979000000000"
 						}
 					}
 					],
@@ -932,27 +932,27 @@ func TestTimeLines(t *testing.T) {
 				"timeLines": {
 					"edges": [
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMwOTc5MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoicm9sZXN0cmVlIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMDk3OTAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509030979000000000
+							"id": "1509030979000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDQ4MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoicm9sZXN0cmVlIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA0ODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031048000000000
+							"id": "1509031048000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDUxMDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoicm9sZXN0cmVlIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA1MTAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031051000000000
+							"id": "1509031051000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDU0MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoicm9sZXN0cmVlIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA1NDAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031054000000000
+							"id": "1509031054000000000"
 						}
 					}
 					],
@@ -978,7 +978,7 @@ func TestTimeLines(t *testing.T) {
 			Variables: `
 			{
 				"first": 4,
-				"after": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDU0MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoicm9sZXN0cmVlIiwiQWdncmVnYXRlSUQiOm51bGx9"
+				"after": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA1NDAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0="
 			}
 			`,
 			ExpectedResult: `
@@ -986,27 +986,27 @@ func TestTimeLines(t *testing.T) {
 				"timeLines": {
 					"edges": [
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDU3MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoicm9sZXN0cmVlIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA1NzAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031057000000000
+							"id": "1509031057000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDYwMDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoicm9sZXN0cmVlIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA2MDAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031060000000000
+							"id": "1509031060000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDgzMDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoicm9sZXN0cmVlIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA4MzAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031083000000000
+							"id": "1509031083000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDg2MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoicm9sZXN0cmVlIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA4NjAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031086000000000
+							"id": "1509031086000000000"
 						}
 					}
 					],
@@ -1032,7 +1032,7 @@ func TestTimeLines(t *testing.T) {
 			Variables: `
 			{
 				"last": 4,
-				"before": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDU0MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoicm9sZXN0cmVlIiwiQWdncmVnYXRlSUQiOm51bGx9"
+				"before": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA1NDAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0="
 			}
 			`,
 			ExpectedResult: `
@@ -1040,21 +1040,21 @@ func TestTimeLines(t *testing.T) {
 				"timeLines": {
 					"edges": [
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDUxMDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoicm9sZXN0cmVlIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA1MTAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031051000000000
+							"id": "1509031051000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMxMDQ4MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoicm9sZXN0cmVlIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA0ODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509031048000000000
+							"id": "1509031048000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoxNTA5MDMwOTc5MDAwMDAwMDAwLCJBZ2dyZWdhdGVUeXBlIjoicm9sZXN0cmVlIiwiQWdncmVnYXRlSUQiOm51bGx9",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMDk3OTAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": 1509030979000000000
+							"id": "1509030979000000000"
 						}
 					}
 					],

--- a/api/graphql/timeline.go
+++ b/api/graphql/timeline.go
@@ -1,6 +1,8 @@
 package graphql
 
 import (
+	"strconv"
+
 	"github.com/sorintlab/sircles/dataloader"
 	"github.com/sorintlab/sircles/readdb"
 	"github.com/sorintlab/sircles/util"
@@ -40,7 +42,7 @@ type timeLineEdgeResolver struct {
 }
 
 func (r *timeLineEdgeResolver) Cursor() (string, error) {
-	return marshalTimeLineCursor(&TimeLineCursor{TimeLineID: r.timeLine.Number(), AggregateType: r.aggregateType, AggregateID: r.aggregateID})
+	return marshalTimeLineCursor(&TimeLineCursor{TimeLineID: strconv.FormatInt(int64(r.timeLine.Number()), 10), AggregateType: r.aggregateType, AggregateID: r.aggregateID})
 }
 
 func (r *timeLineEdgeResolver) TimeLine() *timeLineResolver {

--- a/util/graphql.go
+++ b/util/graphql.go
@@ -8,11 +8,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// We have int64 timelines but javascript cannot handle 64 bit
-// number without using external libraries. A solution will be to marshall into
-// a string thought we'll find problems only when reaching a timeline > than 2^53, probably
-// never.
-// TODO(sgotti) need to document this and find a way to handle it in the ui
 type TimeLineNumber int64
 
 func (_ TimeLineNumber) ImplementsGraphQLType(name string) bool {
@@ -35,6 +30,13 @@ func (tl *TimeLineNumber) UnmarshalGraphQL(input interface{}) error {
 	default:
 		return errors.Errorf("wrong type: %T", input)
 	}
+}
+
+// We have int64 timelines but javascript cannot handle 64 bit
+// number without using external libraries. So we marshal it into
+// a string.
+func (tln TimeLineNumber) MarshalJSON() ([]byte, error) {
+	return strconv.AppendQuote(nil, strconv.FormatInt(int64(tln), 10)), nil
 }
 
 type TimeLine struct {


### PR DESCRIPTION
We have int64 timelines but javascript cannot handle 64 bit number without using
external libraries. The effect is that we lose the nanosecond part. So we
marshal it into a string.