### PR TITLE
*: implement real cqrs and eventsourcing

### DIFF
--- a/aggregate/aggregate.go
+++ b/aggregate/aggregate.go
@@ -1,0 +1,50 @@
+package aggregate
+
+import (
+	"encoding/json"
+
+	"github.com/sorintlab/sircles/command/commands"
+	"github.com/sorintlab/sircles/common"
+	"github.com/sorintlab/sircles/eventstore"
+	"github.com/sorintlab/sircles/util"
+)
+
+type Aggregate interface {
+	ApplyEvents(events []*eventstore.StoredEvent) error
+	HandleCommand(command *commands.Command) ([]eventstore.Event, error)
+	Version() int64
+	ID() string
+	AggregateType() eventstore.AggregateType
+}
+
+type Repository interface {
+	Load(id util.ID) (Aggregate, error)
+}
+
+type HandleCommandError struct {
+	error
+}
+
+func ExecCommand(command *commands.Command, a Aggregate, es *eventstore.EventStore, uidGenerator common.UIDGenerator) (util.ID, int, error) {
+	commandJson, err := json.Marshal(command)
+	if err == nil {
+		log.Infof("executing command on aggregate: %s %s: %s", a.AggregateType(), a.ID(), commandJson)
+	}
+
+	events, err := a.HandleCommand(command)
+	if err != nil {
+		return util.NilID, 0, &HandleCommandError{err}
+	}
+
+	groupID := uidGenerator.UUID("")
+
+	// The events correlationID is the command correlationID
+	// The events causationID is the command ID
+	eventsData, err := eventstore.GenEventData(events, &command.CorrelationID, &command.ID, &groupID, &command.IssuerID)
+	if err != nil {
+		return util.NilID, 0, err
+	}
+
+	se, err := es.WriteEvents(eventsData, a.AggregateType().String(), a.ID(), a.Version())
+	return groupID, len(se), err
+}

--- a/aggregate/aggregate_test.go
+++ b/aggregate/aggregate_test.go
@@ -1,0 +1,97 @@
+package aggregate
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sorintlab/sircles/command/commands"
+	"github.com/sorintlab/sircles/eventstore"
+	"github.com/sorintlab/sircles/util"
+)
+
+type TestUIDGen struct{}
+
+func NewTestUIDGen() *TestUIDGen {
+	return &TestUIDGen{}
+}
+
+func (g *TestUIDGen) UUID(s string) util.ID {
+	if s == "" {
+		u := uuid.NewV4()
+		return util.NewFromUUID(u)
+	}
+	u := uuid.NewV5(uuid.NamespaceDNS, s)
+	return util.NewFromUUID(u)
+}
+
+type testData struct {
+	Aggregate Aggregate
+	State     []*eventstore.StoredEvent
+	Command   *commands.Command
+	Out       []eventstore.Event
+	Err       error
+}
+
+func runTest(t *testing.T, test *testData) {
+	err := test.Aggregate.ApplyEvents(test.State)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out, err := test.Aggregate.HandleCommand(test.Command)
+	if err != nil {
+		if test.Err != nil {
+			if test.Err.Error() != err.Error() {
+				t.Fatalf("got error: %q want error: %q", err, test.Err)
+			}
+			return
+		}
+		t.Fatalf("unexpected error: %v", err)
+	} else {
+		if test.Err != nil {
+			t.Fatalf("expected error: %q but got no error", test.Err)
+		}
+	}
+
+	if !reflect.DeepEqual(out, test.Out) {
+		t.Fatalf("got:\n%s\nwant:\n%s", spew.Sdump(out), spew.Sdump(test.Out))
+	}
+}
+
+func toStoredEvents(events []eventstore.Event, aggregateType eventstore.AggregateType, aggregateID string) ([]*eventstore.StoredEvent, error) {
+	storedEvents := make([]*eventstore.StoredEvent, len(events))
+	var version int64 = 1
+	for i, e := range events {
+		data, err := json.Marshal(e)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		// augment events with common metadata
+		md := &eventstore.EventMetaData{}
+		metaData, err := json.Marshal(md)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		e := &eventstore.StoredEvent{
+			ID:        util.NewFromUUID(uuid.NewV4()),
+			EventType: e.EventType(),
+			Category:  aggregateType.String(),
+			StreamID:  aggregateID,
+			Data:      data,
+			MetaData:  metaData,
+
+			Timestamp: time.Now(),
+			Version:   version,
+		}
+		storedEvents[i] = e
+
+		version++
+	}
+	return storedEvents, nil
+}

--- a/aggregate/batchloader.go
+++ b/aggregate/batchloader.go
@@ -1,0 +1,25 @@
+package aggregate
+
+import (
+	"github.com/sorintlab/sircles/eventstore"
+)
+
+func batchLoader(es *eventstore.EventStore, aggregateID string, a Aggregate) error {
+	var v int64 = 0
+	for {
+		events, err := es.GetEvents(aggregateID, v+1, 100)
+		if err != nil {
+			return err
+		}
+
+		if len(events) == 0 {
+			return nil
+		}
+
+		v = events[len(events)-1].Version
+
+		if err := a.ApplyEvents(events); err != nil {
+			return err
+		}
+	}
+}

--- a/aggregate/log.go
+++ b/aggregate/log.go
@@ -1,0 +1,7 @@
+package aggregate
+
+import (
+	slog "github.com/sorintlab/sircles/log"
+)
+
+var log = slog.S()

--- a/aggregate/member.go
+++ b/aggregate/member.go
@@ -1,0 +1,213 @@
+package aggregate
+
+import (
+	"fmt"
+
+	"github.com/sorintlab/sircles/command/commands"
+	"github.com/sorintlab/sircles/common"
+	"github.com/sorintlab/sircles/eventstore"
+	"github.com/sorintlab/sircles/models"
+	"github.com/sorintlab/sircles/util"
+)
+
+type MemberRepository struct {
+	es           *eventstore.EventStore
+	uidGenerator common.UIDGenerator
+}
+
+func NewMemberRepository(es *eventstore.EventStore, uidGenerator common.UIDGenerator) *MemberRepository {
+	return &MemberRepository{es: es, uidGenerator: uidGenerator}
+}
+
+func (mr *MemberRepository) Load(id util.ID) (*Member, error) {
+	log.Debugf("Load id: %s", id)
+	m := NewMember(mr.uidGenerator, id)
+
+	if err := batchLoader(mr.es, id.String(), m); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+type Member struct {
+	id      util.ID
+	version int64
+
+	userName string
+	fullName string
+	email    string
+	matchUID string
+	isAdmin  bool
+
+	created bool
+
+	uidGenerator common.UIDGenerator
+}
+
+func NewMember(uidGenerator common.UIDGenerator, id util.ID) *Member {
+	return &Member{
+		id:           id,
+		uidGenerator: uidGenerator,
+	}
+}
+
+func (m *Member) Version() int64 {
+	return m.version
+}
+
+func (m *Member) ID() string {
+	return m.id.String()
+}
+
+func (m *Member) AggregateType() eventstore.AggregateType {
+	return eventstore.MemberAggregate
+}
+
+func (m *Member) HandleCommand(command *commands.Command) ([]eventstore.Event, error) {
+	var events []eventstore.Event
+	var err error
+	switch command.CommandType {
+	case commands.CommandTypeCreateMember:
+		events, err = m.HandleCreateMemberCommand(command)
+	case commands.CommandTypeUpdateMember:
+		events, err = m.HandleUpdateMemberCommand(command)
+	case commands.CommandTypeSetMemberPassword:
+		events, err = m.HandleSetMemberPasswordCommand(command)
+	case commands.CommandTypeSetMemberMatchUID:
+		events, err = m.HandleSetMemberMatchUIDCommand(command)
+
+	default:
+		err = fmt.Errorf("unhandled command: %#v", command)
+	}
+
+	return events, err
+}
+
+func (m *Member) HandleCreateMemberCommand(command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	// idempotency: if already created return no events
+	if m.created {
+		return nil, nil
+	}
+
+	c := command.Data.(*commands.CreateMember)
+
+	member := &models.Member{
+		UserName: c.UserName,
+		FullName: c.FullName,
+		Email:    c.Email,
+		IsAdmin:  c.IsAdmin,
+	}
+	member.ID = m.id
+
+	events = append(events, eventstore.NewEventMemberCreated(member))
+
+	if c.Avatar != nil {
+		events = append(events, eventstore.NewEventMemberAvatarSet(m.id, c.Avatar))
+	}
+
+	if c.PasswordHash != "" {
+		events = append(events, eventstore.NewEventMemberPasswordSet(m.id, c.PasswordHash))
+	}
+
+	if c.MatchUID != "" {
+		events = append(events, eventstore.NewEventMemberMatchUIDSet(m.id, c.MatchUID))
+	}
+
+	return events, nil
+}
+
+func (m *Member) HandleUpdateMemberCommand(command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	// if not created return an error
+	if !m.created {
+		return nil, fmt.Errorf("unexistent member")
+	}
+
+	c := command.Data.(*commands.UpdateMember)
+
+	member := &models.Member{
+		UserName: c.UserName,
+		FullName: c.FullName,
+		Email:    c.Email,
+		IsAdmin:  c.IsAdmin,
+	}
+	member.ID = m.id
+
+	events = append(events, eventstore.NewEventMemberUpdated(member))
+
+	if c.Avatar != nil {
+		events = append(events, eventstore.NewEventMemberAvatarSet(m.id, c.Avatar))
+	}
+
+	return events, nil
+}
+
+func (m *Member) HandleSetMemberPasswordCommand(command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.SetMemberPassword)
+
+	events = append(events, eventstore.NewEventMemberPasswordSet(m.id, c.PasswordHash))
+
+	return events, nil
+}
+
+func (m *Member) HandleSetMemberMatchUIDCommand(command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.SetMemberMatchUID)
+
+	events = append(events, eventstore.NewEventMemberMatchUIDSet(m.id, c.MatchUID))
+
+	return events, nil
+}
+
+func (m *Member) ApplyEvents(events []*eventstore.StoredEvent) error {
+	for _, e := range events {
+		if err := m.ApplyEvent(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Member) ApplyEvent(event *eventstore.StoredEvent) error {
+	log.Debugf("event: %v", event)
+
+	data, err := event.UnmarshalData()
+	if err != nil {
+		return err
+	}
+
+	m.version = event.Version
+
+	switch event.EventType {
+	case eventstore.EventTypeMemberCreated:
+		data := data.(*eventstore.EventMemberCreated)
+
+		m.created = true
+		m.userName = data.UserName
+		m.fullName = data.FullName
+		m.email = data.Email
+		m.isAdmin = data.IsAdmin
+
+	case eventstore.EventTypeMemberUpdated:
+		data := data.(*eventstore.EventMemberUpdated)
+
+		m.userName = data.UserName
+		m.fullName = data.FullName
+		m.email = data.Email
+		m.isAdmin = data.IsAdmin
+
+	case eventstore.EventTypeMemberMatchUIDSet:
+		data := data.(*eventstore.EventMemberMatchUIDSet)
+
+		m.matchUID = data.MatchUID
+	}
+
+	return nil
+}

--- a/aggregate/member_test.go
+++ b/aggregate/member_test.go
@@ -1,0 +1,163 @@
+package aggregate
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sorintlab/sircles/command/commands"
+	"github.com/sorintlab/sircles/eventstore"
+	"github.com/sorintlab/sircles/util"
+)
+
+func TestCreateMember(t *testing.T) {
+	uidGenerator := NewTestUIDGen()
+
+	memberID := uidGenerator.UUID("")
+
+	correlationID := uidGenerator.UUID("")
+	causationID := uidGenerator.UUID("")
+
+	aggregate := NewMember(uidGenerator, memberID)
+
+	command := commands.NewCommand(commands.CommandTypeCreateMember, correlationID, causationID, util.NilID, &commands.CreateMember{
+		IsAdmin:      false,
+		UserName:     "user01",
+		FullName:     "User 01",
+		Email:        "user01@example.com",
+		PasswordHash: "passwordHash",
+	})
+
+	out := []eventstore.Event{
+		&eventstore.EventMemberCreated{
+			IsAdmin:  false,
+			UserName: "user01",
+			FullName: "User 01",
+			Email:    "user01@example.com",
+		},
+		&eventstore.EventMemberPasswordSet{
+			PasswordHash: "passwordHash",
+		},
+	}
+
+	test := &testData{
+		Aggregate: aggregate,
+		Command:   command,
+		Out:       out,
+	}
+
+	runTest(t, test)
+}
+
+func setupMember(t *testing.T, memberID util.ID) []*eventstore.StoredEvent {
+	uidGenerator := NewTestUIDGen()
+
+	correlationID := uidGenerator.UUID("")
+	causationID := uidGenerator.UUID("")
+
+	aggregate := NewMember(uidGenerator, memberID)
+
+	command := commands.NewCommand(commands.CommandTypeCreateMember, correlationID, causationID, util.NilID, &commands.CreateMember{
+		IsAdmin:      false,
+		UserName:     "user01",
+		FullName:     "User 01",
+		Email:        "user01@example.com",
+		PasswordHash: "passwordHash",
+	})
+
+	out := []eventstore.Event{
+		&eventstore.EventMemberCreated{
+			IsAdmin:  false,
+			UserName: "user01",
+			FullName: "User 01",
+			Email:    "user01@example.com",
+		},
+		&eventstore.EventMemberPasswordSet{
+			PasswordHash: "passwordHash",
+		},
+	}
+
+	out, err := aggregate.HandleCommand(command)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	storedEvents, err := toStoredEvents(out, aggregate.AggregateType(), aggregate.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	return storedEvents
+}
+
+func TestUpdateMember(t *testing.T) {
+	uidGenerator := NewTestUIDGen()
+
+	memberID := uidGenerator.UUID("")
+	storedEvents := setupMember(t, memberID)
+
+	correlationID := uidGenerator.UUID("")
+	causationID := uidGenerator.UUID("")
+
+	aggregate := NewMember(uidGenerator, memberID)
+
+	command := commands.NewCommand(commands.CommandTypeUpdateMember, correlationID, causationID, util.NilID, &commands.UpdateMember{
+		IsAdmin:  false,
+		UserName: "updateduser01",
+		FullName: "Updated User 01",
+		Email:    "updateduser01@example.com",
+	})
+
+	out := []eventstore.Event{
+		&eventstore.EventMemberUpdated{
+			IsAdmin:  false,
+			UserName: "updateduser01",
+			FullName: "Updated User 01",
+			Email:    "updateduser01@example.com",
+		},
+	}
+
+	test := &testData{
+		State:     storedEvents,
+		Aggregate: aggregate,
+		Command:   command,
+		Out:       out,
+	}
+
+	runTest(t, test)
+}
+
+func TestUpdateNotExistingMember(t *testing.T) {
+	uidGenerator := NewTestUIDGen()
+
+	memberID := uidGenerator.UUID("")
+
+	correlationID := uidGenerator.UUID("")
+	causationID := uidGenerator.UUID("")
+
+	aggregate := NewMember(uidGenerator, memberID)
+
+	command := commands.NewCommand(commands.CommandTypeUpdateMember, correlationID, causationID, util.NilID, &commands.UpdateMember{
+		IsAdmin:  false,
+		UserName: "user01",
+		FullName: "User 01",
+		Email:    "user01@example.com",
+	})
+
+	out := []eventstore.Event{
+		&eventstore.EventMemberUpdated{
+			IsAdmin:  false,
+			UserName: "user01",
+			FullName: "User 01",
+			Email:    "user01@example.com",
+		},
+	}
+
+	test := &testData{
+		Aggregate: aggregate,
+		Command:   command,
+		Out:       out,
+		Err:       fmt.Errorf("unexistent member"),
+	}
+
+	runTest(t, test)
+}

--- a/aggregate/memberchange.go
+++ b/aggregate/memberchange.go
@@ -1,0 +1,169 @@
+package aggregate
+
+import (
+	"fmt"
+
+	"github.com/sorintlab/sircles/command/commands"
+	"github.com/sorintlab/sircles/common"
+	"github.com/sorintlab/sircles/eventstore"
+	"github.com/sorintlab/sircles/models"
+	"github.com/sorintlab/sircles/util"
+)
+
+type MemberChangeRepository struct {
+	es           *eventstore.EventStore
+	uidGenerator common.UIDGenerator
+}
+
+func NewMemberChangeRepository(es *eventstore.EventStore, uidGenerator common.UIDGenerator) *MemberChangeRepository {
+	return &MemberChangeRepository{es: es, uidGenerator: uidGenerator}
+}
+
+func (mr *MemberChangeRepository) Load(id util.ID) (*MemberChange, error) {
+	log.Debugf("Load id: %s", id)
+	m, err := NewMemberChange(mr.es, mr.uidGenerator, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := batchLoader(mr.es, id.String(), m); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+type MemberChange struct {
+	id      util.ID
+	version int64
+
+	completed bool
+
+	es           *eventstore.EventStore
+	uidGenerator common.UIDGenerator
+}
+
+func NewMemberChange(es *eventstore.EventStore, uidGenerator common.UIDGenerator, id util.ID) (*MemberChange, error) {
+	return &MemberChange{
+		id:           id,
+		es:           es,
+		uidGenerator: uidGenerator,
+	}, nil
+}
+
+func (m *MemberChange) Version() int64 {
+	return m.version
+}
+
+func (m *MemberChange) ID() string {
+	return m.id.String()
+}
+
+func (m *MemberChange) AggregateType() eventstore.AggregateType {
+	return eventstore.MemberChangeAggregate
+}
+
+func (m *MemberChange) HandleCommand(command *commands.Command) ([]eventstore.Event, error) {
+	var events []eventstore.Event
+	var err error
+
+	// skip if already completed
+	if m.completed {
+		return events, nil
+	}
+
+	switch command.CommandType {
+	case commands.CommandTypeRequestCreateMember:
+		events, err = m.HandleRequestCreateMemberCommand(command)
+	case commands.CommandTypeRequestUpdateMember:
+		events, err = m.HandleRequestUpdateMemberCommand(command)
+	case commands.CommandTypeRequestSetMemberMatchUID:
+		events, err = m.HandleRequestSetMemberMatchUIDCommand(command)
+	case commands.CommandTypeCompleteRequest:
+		events, err = m.HandleCompleteRequestCommand(command)
+
+	default:
+		err = fmt.Errorf("unhandled command: %#v", command)
+	}
+
+	return events, err
+}
+
+func (m *MemberChange) HandleRequestCreateMemberCommand(command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.RequestCreateMember)
+
+	member := &models.Member{
+		UserName: c.UserName,
+		FullName: c.FullName,
+		Email:    c.Email,
+		IsAdmin:  c.IsAdmin,
+	}
+	member.ID = c.MemberID
+
+	events = append(events, eventstore.NewEventMemberChangeCreateRequested(m.id, member, c.MatchUID, c.PasswordHash, c.Avatar))
+
+	return events, nil
+}
+
+func (m *MemberChange) HandleRequestUpdateMemberCommand(command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.RequestUpdateMember)
+
+	member := &models.Member{
+		UserName: c.UserName,
+		FullName: c.FullName,
+		Email:    c.Email,
+		IsAdmin:  c.IsAdmin,
+	}
+	member.ID = c.MemberID
+
+	events = append(events, eventstore.NewEventMemberChangeUpdateRequested(m.id, member, c.Avatar, c.PrevUserName, c.PrevEmail))
+
+	return events, nil
+}
+
+func (m *MemberChange) HandleRequestSetMemberMatchUIDCommand(command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.RequestSetMemberMatchUID)
+
+	events = append(events, eventstore.NewEventMemberChangeSetMatchUIDRequested(m.id, c.MemberID, c.MatchUID))
+
+	return events, nil
+}
+
+func (m *MemberChange) HandleCompleteRequestCommand(command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.CompleteRequest)
+
+	events = append(events, eventstore.NewEventMemberChangeCompleted(m.id, c.Error, c.Reason))
+
+	return events, nil
+}
+
+func (m *MemberChange) ApplyEvents(events []*eventstore.StoredEvent) error {
+	for _, e := range events {
+		if err := m.ApplyEvent(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *MemberChange) ApplyEvent(event *eventstore.StoredEvent) error {
+	log.Debugf("event: %v", event)
+
+	m.version = event.Version
+
+	switch event.EventType {
+	case eventstore.EventTypeMemberChangeCompleted:
+		m.completed = true
+
+	}
+
+	return nil
+}

--- a/aggregate/rolestree.go
+++ b/aggregate/rolestree.go
@@ -1,0 +1,2112 @@
+package aggregate
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+
+	"github.com/sorintlab/sircles/command/commands"
+	"github.com/sorintlab/sircles/common"
+	"github.com/sorintlab/sircles/db"
+	"github.com/sorintlab/sircles/eventstore"
+	"github.com/sorintlab/sircles/models"
+	"github.com/sorintlab/sircles/util"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/pkg/errors"
+)
+
+const (
+	dbName = "rolestree.db"
+)
+
+func newDB(dataDir string) (*db.DB, error) {
+	return db.NewDB("sqlite3", filepath.Join(dataDir, dbName))
+}
+
+type RolesTreeRepository struct {
+	dataDir      string
+	es           *eventstore.EventStore
+	uidGenerator common.UIDGenerator
+}
+
+func NewRolesTreeRepository(dataDir string, es *eventstore.EventStore, uidGenerator common.UIDGenerator) *RolesTreeRepository {
+	return &RolesTreeRepository{dataDir: dataDir, es: es, uidGenerator: uidGenerator}
+}
+
+func (r *RolesTreeRepository) Load(id util.ID) (*RolesTree, error) {
+	log.Debugf("Load id: %s", id)
+
+	rt, err := NewRolesTree(r.dataDir, r.uidGenerator, id)
+	if err != nil {
+		return nil, err
+	}
+
+	ldb, err := newDB(r.dataDir)
+	if err != nil {
+		return nil, err
+	}
+	defer ldb.Close()
+
+	for {
+		var n int
+		var version int64
+
+		// get current snapshotdb version, note that this isn't in the same
+		// applyEvents transaction so it can be behind. ApplyEvent will handle
+		// this skipping already handled events
+		err := ldb.Do(func(tx *db.Tx) error {
+			var err error
+			version, err = rt.curVersion(tx)
+			return err
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		n, err = r.load(id, rt, version)
+		if err != nil {
+			return nil, err
+		}
+		if n == 0 {
+			err := ldb.Do(func(tx *db.Tx) error {
+				return rt.CheckBrokenEdges(tx)
+			})
+			if err != nil {
+				return nil, err
+			}
+			break
+		}
+	}
+
+	return rt, nil
+}
+
+func (r *RolesTreeRepository) load(id util.ID, rt *RolesTree, version int64) (int, error) {
+	events, err := r.es.GetEvents(id.String(), version+1, 100)
+	if err != nil {
+		return 0, err
+	}
+
+	if err := rt.ApplyEvents(events); err != nil {
+		return 0, err
+	}
+
+	return len(events), nil
+}
+
+type RolesTree struct {
+	dataDir string
+	id      util.ID
+	version int64
+
+	uidGenerator common.UIDGenerator
+}
+
+func NewRolesTree(dataDir string, uidGenerator common.UIDGenerator, id util.ID) (*RolesTree, error) {
+	ldb, err := newDB(dataDir)
+	if err != nil {
+		return nil, err
+	}
+	defer ldb.Close()
+
+	err = ldb.Do(func(tx *db.Tx) error {
+		return tx.Do(func(tx *db.WrappedTx) error {
+			for _, stmt := range rolesTreeDBCreateStmts {
+				if _, err := tx.Exec(stmt); err != nil {
+					return errors.Wrapf(err, "create failed")
+				}
+			}
+			return nil
+		})
+	})
+
+	return &RolesTree{
+		dataDir:      dataDir,
+		id:           id,
+		uidGenerator: uidGenerator,
+	}, nil
+}
+
+func (r *RolesTree) Version() int64 {
+	return r.version
+}
+
+func (r *RolesTree) ID() string {
+	return r.id.String()
+}
+
+func (r *RolesTree) AggregateType() eventstore.AggregateType {
+	return eventstore.RolesTreeAggregate
+}
+
+func (r *RolesTree) HandleCommand(command *commands.Command) ([]eventstore.Event, error) {
+	ldb, err := newDB(r.dataDir)
+	if err != nil {
+		return nil, err
+	}
+	defer ldb.Close()
+
+	var version int64
+	var events []eventstore.Event
+	err = ldb.Do(func(tx *db.Tx) error {
+		var err error
+
+		switch command.CommandType {
+		case commands.CommandTypeSetupRootRole:
+			events, err = r.HandleSetupRootRoleCommand(tx, command)
+		case commands.CommandTypeUpdateRootRole:
+			events, err = r.HandleUpdateRootRoleCommand(tx, command)
+		case commands.CommandTypeCircleCreateChildRole:
+			events, err = r.HandleCircleCreateChildRoleCommand(tx, command)
+		case commands.CommandTypeCircleUpdateChildRole:
+			events, err = r.HandleCircleUpdateChildRoleCommand(tx, command)
+		case commands.CommandTypeCircleDeleteChildRole:
+			events, err = r.HandleCircleDeleteChildRoleCommand(tx, command)
+		case commands.CommandTypeSetRoleAdditionalContent:
+			events, err = r.HandleSetRoleAdditionalContentCommand(tx, command)
+		case commands.CommandTypeCircleAddDirectMember:
+			events, err = r.HandleCircleAddDirectMemberCommand(tx, command)
+		case commands.CommandTypeCircleRemoveDirectMember:
+			events, err = r.HandleCircleRemoveDirectMemberCommand(tx, command)
+		case commands.CommandTypeCircleSetLeadLinkMember:
+			events, err = r.HandleCircleSetLeadLinkMemberCommand(tx, command)
+		case commands.CommandTypeCircleUnsetLeadLinkMember:
+			events, err = r.HandleCircleUnsetLeadLinkMemberCommand(tx, command)
+		case commands.CommandTypeCircleSetCoreRoleMember:
+			events, err = r.HandleCircleSetCoreRoleMemberCommand(tx, command)
+		case commands.CommandTypeCircleUnsetCoreRoleMember:
+			events, err = r.HandleCircleUnsetCoreRoleMemberCommand(tx, command)
+		case commands.CommandTypeRoleAddMember:
+			events, err = r.HandleRoleAddMemberCommand(tx, command)
+		case commands.CommandTypeRoleRemoveMember:
+			events, err = r.HandleRoleRemoveMemberCommand(tx, command)
+		case commands.CommandTypeRoleUpdateMember:
+			events, err = r.HandleRoleUpdateMemberCommand(tx, command)
+
+		default:
+			err = errors.Errorf("unhandled command: %#v", command)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		version, err = r.curVersion(tx)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// update the version we operated on here since the snapshot db is shared
+	// between all the rolestree instances on this server instance
+	r.version = version
+
+	return events, nil
+}
+
+func (r *RolesTree) HandleSetupRootRoleCommand(tx *db.Tx, command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.SetupRootRole)
+
+	role := &models.Role{
+		RoleType: models.RoleTypeCircle,
+		Name:     c.Name,
+	}
+	role.ID = c.RootRoleID
+
+	events = append(events, eventstore.NewEventRoleCreated(role, nil))
+
+	es, err := r.roleAddCoreRoles(role, true)
+	if err != nil {
+		return nil, err
+	}
+	events = append(events, es...)
+
+	return events, nil
+}
+
+func (r *RolesTree) HandleUpdateRootRoleCommand(tx *db.Tx, command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.UpdateRootRole)
+
+	role, err := r.role(tx, c.UpdateRootRoleChange.ID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s doesn't exist", c.UpdateRootRoleChange.ID)
+	}
+
+	rootRole, err := r.rootRole(tx)
+	if err != nil {
+		return nil, err
+	}
+	if role.ID != rootRole.ID {
+		return nil, errors.Errorf("role with id %s isn't the root role", c.UpdateRootRoleChange.ID)
+	}
+	if c.UpdateRootRoleChange.NameChanged {
+		rootRole.Name = c.UpdateRootRoleChange.Name
+	}
+
+	if c.UpdateRootRoleChange.PurposeChanged {
+		rootRole.Purpose = c.UpdateRootRoleChange.Purpose
+	}
+
+	events = append(events, eventstore.NewEventRoleUpdated(rootRole))
+
+	domains, err := r.roleDomains(tx, rootRole.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	accountabilities, err := r.roleAccountabilities(tx, rootRole.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, createDomainChange := range c.UpdateRootRoleChange.CreateDomainChanges {
+		domain := models.Domain{}
+		domain.Description = createDomainChange.Description
+		domain.ID = r.uidGenerator.UUID(domain.Description)
+
+		events = append(events, eventstore.NewEventRoleDomainCreated(rootRole.ID, &domain))
+	}
+
+	for _, deleteDomainChange := range c.UpdateRootRoleChange.DeleteDomainChanges {
+		found := false
+		for _, d := range domains {
+			if deleteDomainChange.ID == d.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, errors.Errorf("cannot delete unexistent domain %s", deleteDomainChange.ID)
+		}
+		events = append(events, eventstore.NewEventRoleDomainDeleted(rootRole.ID, deleteDomainChange.ID))
+	}
+
+	for _, updateDomainChange := range c.UpdateRootRoleChange.UpdateDomainChanges {
+		var domain *models.Domain
+		for _, d := range domains {
+			if updateDomainChange.ID == d.ID {
+				domain = d
+				break
+			}
+		}
+		if domain == nil {
+			return nil, errors.Errorf("cannot update unexistent domain %s", updateDomainChange.ID)
+		}
+		if updateDomainChange.DescriptionChanged {
+			domain.Description = updateDomainChange.Description
+		}
+		events = append(events, eventstore.NewEventRoleDomainUpdated(rootRole.ID, domain))
+	}
+
+	for _, createAccountabilityChange := range c.UpdateRootRoleChange.CreateAccountabilityChanges {
+		accountability := models.Accountability{}
+		accountability.Description = createAccountabilityChange.Description
+		accountability.ID = r.uidGenerator.UUID(accountability.Description)
+
+		events = append(events, eventstore.NewEventRoleAccountabilityCreated(rootRole.ID, &accountability))
+	}
+
+	for _, deleteAccountabilityChange := range c.UpdateRootRoleChange.DeleteAccountabilityChanges {
+		found := false
+		for _, d := range accountabilities {
+			if deleteAccountabilityChange.ID == d.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, errors.Errorf("cannot delete unexistent accountability %s", deleteAccountabilityChange.ID)
+		}
+		events = append(events, eventstore.NewEventRoleAccountabilityDeleted(rootRole.ID, deleteAccountabilityChange.ID))
+	}
+
+	for _, updateAccountabilityChange := range c.UpdateRootRoleChange.UpdateAccountabilityChanges {
+		var accountability *models.Accountability
+		for _, d := range accountabilities {
+			if updateAccountabilityChange.ID == d.ID {
+				accountability = d
+				break
+			}
+		}
+		if accountability == nil {
+			return nil, errors.Errorf("cannot update unexistent accountability %s", updateAccountabilityChange.ID)
+		}
+		if updateAccountabilityChange.DescriptionChanged {
+			accountability.Description = updateAccountabilityChange.Description
+		}
+		events = append(events, eventstore.NewEventRoleAccountabilityUpdated(rootRole.ID, accountability))
+	}
+
+	return events, nil
+}
+
+func (r *RolesTree) HandleCircleCreateChildRoleCommand(tx *db.Tx, command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.CircleCreateChildRole)
+
+	// check that role exists
+	role, err := r.role(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s doesn't exist", c.RoleID)
+	}
+	if role.RoleType != models.RoleTypeCircle {
+		return nil, errors.Errorf("role with id %s isn't a circle", c.RoleID)
+	}
+
+	testNewRole, err := r.role(tx, c.NewRoleID)
+	if err != nil {
+		return nil, err
+	}
+	if testNewRole != nil {
+		return nil, errors.Errorf("role with id %s already exists", c.NewRoleID)
+	}
+
+	switch c.CreateRoleChange.RoleType {
+	case models.RoleTypeNormal:
+	case models.RoleTypeCircle:
+	default:
+		return nil, errors.Errorf("wrong role type: %q", c.CreateRoleChange.RoleType)
+	}
+
+	childs, err := r.childRoles(tx, role.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check that the roles to move from parent are valid
+	for _, rfp := range c.CreateRoleChange.RolesFromParent {
+		found := false
+		for _, child := range childs {
+			if child.ID == rfp {
+				if child.RoleType.IsCoreRoleType() {
+					return nil, errors.Errorf("role %s to move from role inside new child role is a core role type (not a normal role or a circle)", rfp)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, errors.Errorf("role %s to move from parent is not a child of role %s", rfp, role.ID)
+		}
+	}
+
+	newChildRole := &models.Role{
+		Name:     c.CreateRoleChange.Name,
+		RoleType: c.CreateRoleChange.RoleType,
+		Purpose:  c.CreateRoleChange.Purpose,
+	}
+	newChildRole.ID = c.NewRoleID
+
+	events = append(events, eventstore.NewEventRoleCreated(newChildRole, &c.RoleID))
+
+	for _, createDomainChange := range c.CreateRoleChange.CreateDomainChanges {
+		domain := models.Domain{}
+		domain.Description = createDomainChange.Description
+
+		domain.ID = r.uidGenerator.UUID(domain.Description)
+
+		events = append(events, eventstore.NewEventRoleDomainCreated(newChildRole.ID, &domain))
+	}
+
+	for _, createAccountabilityChange := range c.CreateRoleChange.CreateAccountabilityChanges {
+		accountability := models.Accountability{}
+		accountability.Description = createAccountabilityChange.Description
+
+		accountability.ID = r.uidGenerator.UUID(accountability.Description)
+
+		events = append(events, eventstore.NewEventRoleAccountabilityCreated(newChildRole.ID, &accountability))
+	}
+
+	// Add core roles to circle
+	if c.CreateRoleChange.RoleType == models.RoleTypeCircle {
+		es, err := r.roleAddCoreRoles(newChildRole, false)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, es...)
+	}
+
+	for _, child := range childs {
+		fromParent := false
+		for _, rfp := range c.CreateRoleChange.RolesFromParent {
+			if child.ID == rfp {
+				fromParent = true
+			}
+		}
+		if fromParent {
+			events = append(events, eventstore.NewEventRoleChangedParent(child.ID, &newChildRole.ID))
+		}
+	}
+
+	return events, nil
+}
+
+func (r *RolesTree) HandleCircleUpdateChildRoleCommand(tx *db.Tx, command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.CircleUpdateChildRole)
+
+	role, err := r.role(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s doesn't exist", c.RoleID)
+	}
+	if role.RoleType != models.RoleTypeCircle {
+		return nil, errors.Errorf("role with id %s isn't a circle", c.RoleID)
+	}
+
+	childRole, err := r.role(tx, c.UpdateRoleChange.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	childRoleParent, err := r.roleParent(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s is the root role", c.UpdateRoleChange.ID)
+	}
+	if childRoleParent.ID != c.RoleID {
+		return nil, errors.Errorf("role with id %s doesn't have parent circle with id %s", c.UpdateRoleChange.ID, c.RoleID)
+	}
+
+	childs, err := r.childRoles(tx, childRole.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	pChilds, err := r.childRoles(tx, role.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check that the roles to keep are valid
+	for _, rtp := range c.UpdateRoleChange.RolesToParent {
+		found := false
+		for _, child := range childs {
+			if child.ID == rtp {
+				if child.RoleType.IsCoreRoleType() {
+					return nil, errors.Errorf("role %s to move to parent is a core role type (not a normal role or a circle)", rtp)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, errors.Errorf("role %s to move to parent is not a child of role %s", rtp, childRole.ID)
+		}
+	}
+
+	// Check that the roles to move from parent are valid
+	for _, rfp := range c.UpdateRoleChange.RolesFromParent {
+		found := false
+		for _, pChild := range pChilds {
+			if pChild.ID == rfp {
+				if pChild.RoleType.IsCoreRoleType() {
+					return nil, errors.Errorf("role %s to move from parent is a core role type (not a normal role or a circle)", rfp)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, errors.Errorf("role %s to move from parent is not a child of parent role %s", rfp, role.ID)
+		}
+	}
+
+	if c.UpdateRoleChange.NameChanged {
+		if childRole.RoleType.IsCoreRoleType() {
+			return nil, errors.Errorf("cannot change core role name")
+		}
+		childRole.Name = c.UpdateRoleChange.Name
+	}
+
+	if c.UpdateRoleChange.PurposeChanged {
+		childRole.Purpose = c.UpdateRoleChange.Purpose
+	}
+
+	if c.UpdateRoleChange.MakeCircle {
+		if childRole.RoleType != models.RoleTypeNormal {
+			return nil, errors.Errorf("role with id %s of type %s cannot be transformed in a circle", childRole.ID, childRole.RoleType)
+		}
+		childRole.RoleType = models.RoleTypeCircle
+
+		// remove members filling the role ince it will become a circle
+		roleMembersIDs, err := r.roleMembersIDs(tx, childRole.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, roleMemberID := range roleMembersIDs {
+			events = append(events, eventstore.NewEventRoleMemberRemoved(childRole.ID, roleMemberID))
+		}
+	}
+
+	if c.UpdateRoleChange.MakeRole {
+		if childRole.RoleType != models.RoleTypeCircle {
+			return nil, errors.Errorf("role with id %s isn't a circle", childRole.ID)
+		}
+
+		childRole.RoleType = models.RoleTypeNormal
+
+		circleDirectMembersIDs, err := r.circleDirectMembersIDs(tx, childRole.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		// Remove circle direct members since they don't exist on a role
+		for _, circleDirectMemberID := range circleDirectMembersIDs {
+			events = append(events, eventstore.NewEventCircleDirectMemberRemoved(childRole.ID, circleDirectMemberID))
+		}
+
+		// Remove circle leadLink member
+		es, err := r.circleUnsetLeadLinkMember(tx, childRole.ID)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, es...)
+
+		// Remove circle core roles members
+		for _, rt := range []models.RoleType{models.RoleTypeFacilitator, models.RoleTypeSecretary, models.RoleTypeRepLink} {
+			es, err := r.circleUnsetCoreRoleMember(tx, rt, childRole.ID)
+			if err != nil {
+				return nil, err
+			}
+			events = append(events, es...)
+		}
+	}
+
+	for _, child := range childs {
+		toParent := false
+		for _, rtp := range c.UpdateRoleChange.RolesToParent {
+			if child.ID == rtp {
+				toParent = true
+			}
+		}
+		if toParent {
+			events = append(events, eventstore.NewEventRoleChangedParent(child.ID, &role.ID))
+		} else {
+			if c.UpdateRoleChange.MakeRole {
+				// recursive delete for sub roles
+				es, err := r.deleteRoleRecursive(tx, child.ID, nil)
+				if err != nil {
+					return nil, err
+				}
+				events = append(events, es...)
+			}
+		}
+	}
+
+	events = append(events, eventstore.NewEventRoleUpdated(childRole))
+
+	if c.UpdateRoleChange.MakeCircle {
+		// Add core roles to circle
+		es, err := r.roleAddCoreRoles(childRole, false)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, es...)
+	}
+
+	for _, pChild := range pChilds {
+		fromParent := false
+		for _, rfp := range c.UpdateRoleChange.RolesFromParent {
+			if pChild.ID == rfp {
+				fromParent = true
+			}
+		}
+		if fromParent {
+			events = append(events, eventstore.NewEventRoleChangedParent(pChild.ID, &childRole.ID))
+		}
+	}
+
+	domains, err := r.roleDomains(tx, childRole.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	accountabilities, err := r.roleAccountabilities(tx, childRole.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, createDomainChange := range c.UpdateRoleChange.CreateDomainChanges {
+		domain := models.Domain{}
+		domain.Description = createDomainChange.Description
+		domain.ID = r.uidGenerator.UUID(domain.Description)
+
+		events = append(events, eventstore.NewEventRoleDomainCreated(childRole.ID, &domain))
+	}
+
+	for _, deleteDomainChange := range c.UpdateRoleChange.DeleteDomainChanges {
+		found := false
+		for _, d := range domains {
+			if deleteDomainChange.ID == d.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, errors.Errorf("cannot delete unexistent domain %s", deleteDomainChange.ID)
+		}
+		events = append(events, eventstore.NewEventRoleDomainDeleted(childRole.ID, deleteDomainChange.ID))
+	}
+
+	for _, updateDomainChange := range c.UpdateRoleChange.UpdateDomainChanges {
+		var domain *models.Domain
+		for _, d := range domains {
+			if updateDomainChange.ID == d.ID {
+				domain = d
+				break
+			}
+		}
+		if domain == nil {
+			return nil, errors.Errorf("cannot update unexistent domain %s", updateDomainChange.ID)
+		}
+		if updateDomainChange.DescriptionChanged {
+			domain.Description = updateDomainChange.Description
+		}
+		events = append(events, eventstore.NewEventRoleDomainUpdated(childRole.ID, domain))
+	}
+
+	for _, createAccountabilityChange := range c.UpdateRoleChange.CreateAccountabilityChanges {
+		accountability := models.Accountability{}
+		accountability.Description = createAccountabilityChange.Description
+		accountability.ID = r.uidGenerator.UUID(accountability.Description)
+
+		events = append(events, eventstore.NewEventRoleAccountabilityCreated(childRole.ID, &accountability))
+	}
+
+	for _, deleteAccountabilityChange := range c.UpdateRoleChange.DeleteAccountabilityChanges {
+		found := false
+		for _, d := range accountabilities {
+			if deleteAccountabilityChange.ID == d.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, errors.Errorf("cannot delete unexistent accountability %s", deleteAccountabilityChange.ID)
+		}
+		events = append(events, eventstore.NewEventRoleAccountabilityDeleted(childRole.ID, deleteAccountabilityChange.ID))
+	}
+
+	for _, updateAccountabilityChange := range c.UpdateRoleChange.UpdateAccountabilityChanges {
+		var accountability *models.Accountability
+		for _, d := range accountabilities {
+			if updateAccountabilityChange.ID == d.ID {
+				accountability = d
+				break
+			}
+		}
+		if accountability == nil {
+			return nil, errors.Errorf("cannot update unexistent accountability %s", updateAccountabilityChange.ID)
+		}
+		if updateAccountabilityChange.DescriptionChanged {
+			accountability.Description = updateAccountabilityChange.Description
+		}
+		events = append(events, eventstore.NewEventRoleAccountabilityUpdated(childRole.ID, accountability))
+	}
+
+	return events, nil
+}
+
+func (r *RolesTree) HandleCircleDeleteChildRoleCommand(tx *db.Tx, command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.CircleDeleteChildRole)
+
+	role, err := r.role(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s doesn't exist", c.RoleID)
+	}
+	if role.RoleType != models.RoleTypeCircle {
+		return nil, errors.Errorf("role with id %s isn't a circle", c.RoleID)
+	}
+
+	childRole, err := r.role(tx, c.DeleteRoleChange.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	childRoleParent, err := r.roleParent(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s is the root role", c.DeleteRoleChange.ID)
+	}
+	if childRoleParent.ID != c.RoleID {
+		return nil, errors.Errorf("role with id %s doesn't have parent circle with id %s", c.DeleteRoleChange.ID, c.RoleID)
+	}
+
+	childs, err := r.childRoles(tx, childRole.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	skipchilds := []util.ID{}
+	for _, child := range childs {
+		toParent := false
+		for _, rtp := range c.DeleteRoleChange.RolesToParent {
+			if child.ID == rtp {
+				toParent = true
+				skipchilds = append(skipchilds, child.ID)
+			}
+		}
+		if toParent {
+			events = append(events, eventstore.NewEventRoleChangedParent(child.ID, &role.ID))
+		}
+	}
+
+	es, err := r.deleteRoleRecursive(tx, childRole.ID, skipchilds)
+	if err != nil {
+		return nil, err
+	}
+	events = append(events, es...)
+
+	return events, nil
+}
+
+func (r *RolesTree) HandleSetRoleAdditionalContentCommand(tx *db.Tx, command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.SetRoleAdditionalContent)
+
+	role, err := r.role(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s doesn't exist", c.RoleID)
+	}
+
+	events = append(events, eventstore.NewEventRoleAdditionalContentSet(c.RoleID, c.Content))
+
+	return events, nil
+}
+
+func (r *RolesTree) HandleCircleAddDirectMemberCommand(tx *db.Tx, command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.CircleAddDirectMember)
+
+	role, err := r.role(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s doesn't exist", c.RoleID)
+	}
+	if role.RoleType != models.RoleTypeCircle {
+		return nil, errors.Errorf("role with id %s isn't a circle", c.RoleID)
+	}
+
+	events = append(events, eventstore.NewEventCircleDirectMemberAdded(c.RoleID, c.MemberID))
+
+	return events, nil
+}
+
+func (r *RolesTree) HandleCircleRemoveDirectMemberCommand(tx *db.Tx, command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.CircleRemoveDirectMember)
+
+	role, err := r.role(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s doesn't exist", c.RoleID)
+	}
+	if role.RoleType != models.RoleTypeCircle {
+		return nil, errors.Errorf("role with id %s isn't a circle", c.RoleID)
+	}
+
+	roleMembersIDs, err := r.roleMembersIDs(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+
+	found := false
+	for _, roleMemberID := range roleMembersIDs {
+
+		if c.MemberID == roleMemberID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, errors.Errorf("member with id %s is not a member of role %s", c.MemberID, c.RoleID)
+	}
+
+	events = append(events, eventstore.NewEventCircleDirectMemberRemoved(c.RoleID, c.MemberID))
+
+	return events, nil
+}
+
+func (r *RolesTree) HandleCircleSetLeadLinkMemberCommand(tx *db.Tx, command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.CircleSetLeadLinkMember)
+
+	role, err := r.role(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s doesn't exist", c.RoleID)
+	}
+	if role.RoleType != models.RoleTypeCircle {
+		return nil, errors.Errorf("role with id %s isn't a circle", c.RoleID)
+	}
+	leadLinkRole, err := r.circleCoreRole(tx, c.RoleID, models.RoleTypeLeadLink)
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove previous lead link
+	es, err := r.circleUnsetLeadLinkMember(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	events = append(events, es...)
+
+	events = append(events, eventstore.NewEventCircleLeadLinkMemberSet(c.RoleID, leadLinkRole.ID, c.MemberID))
+
+	return events, nil
+}
+
+func (r *RolesTree) HandleCircleUnsetLeadLinkMemberCommand(tx *db.Tx, command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.CircleUnsetLeadLinkMember)
+
+	role, err := r.role(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s doesn't exist", c.RoleID)
+	}
+	if role.RoleType != models.RoleTypeCircle {
+		return nil, errors.Errorf("role with id %s isn't a circle", c.RoleID)
+	}
+	es, err := r.circleUnsetLeadLinkMember(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	events = append(events, es...)
+
+	return events, nil
+}
+
+func (r *RolesTree) HandleCircleSetCoreRoleMemberCommand(tx *db.Tx, command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.CircleSetCoreRoleMember)
+
+	role, err := r.role(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s doesn't exist", c.RoleID)
+	}
+	if role.RoleType != models.RoleTypeCircle {
+		return nil, errors.Errorf("role with id %s isn't a circle", c.RoleID)
+	}
+	coreRole, err := r.circleCoreRole(tx, c.RoleID, c.RoleType)
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove previous lead link
+	es, err := r.circleUnsetCoreRoleMember(tx, c.RoleType, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	events = append(events, es...)
+
+	events = append(events, eventstore.NewEventCircleCoreRoleMemberSet(c.RoleID, coreRole.ID, c.MemberID, c.RoleType, c.ElectionExpiration))
+
+	return events, nil
+}
+
+func (r *RolesTree) HandleCircleUnsetCoreRoleMemberCommand(tx *db.Tx, command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.CircleUnsetCoreRoleMember)
+
+	role, err := r.role(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s doesn't exist", c.RoleID)
+	}
+	if role.RoleType != models.RoleTypeCircle {
+		return nil, errors.Errorf("role with id %s isn't a circle", c.RoleID)
+	}
+
+	es, err := r.circleUnsetCoreRoleMember(tx, c.RoleType, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	events = append(events, es...)
+
+	return events, nil
+}
+
+func (r *RolesTree) HandleRoleAddMemberCommand(tx *db.Tx, command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.RoleAddMember)
+
+	role, err := r.role(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s doesn't exist", c.RoleID)
+	}
+	if role.RoleType != models.RoleTypeNormal {
+		return nil, errors.Errorf("role with id %s isn't a normal role", c.RoleID)
+	}
+
+	events = append(events, eventstore.NewEventRoleMemberAdded(c.RoleID, c.MemberID, c.Focus, c.NoCoreMember))
+
+	return events, nil
+}
+
+func (r *RolesTree) HandleRoleRemoveMemberCommand(tx *db.Tx, command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.RoleRemoveMember)
+
+	role, err := r.role(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s doesn't exist", c.RoleID)
+	}
+	if role.RoleType != models.RoleTypeNormal {
+		return nil, errors.Errorf("role with id %s isn't a normal role", c.RoleID)
+	}
+
+	roleMembersIDs, err := r.roleMembersIDs(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+
+	found := false
+	for _, roleMemberID := range roleMembersIDs {
+
+		if c.MemberID == roleMemberID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, errors.Errorf("member with id %s is not a member of role %s", c.MemberID, c.RoleID)
+	}
+
+	events = append(events, eventstore.NewEventRoleMemberRemoved(c.RoleID, c.MemberID))
+
+	return events, nil
+}
+
+func (r *RolesTree) HandleRoleUpdateMemberCommand(tx *db.Tx, command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.RoleUpdateMember)
+
+	role, err := r.role(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s doesn't exist", c.RoleID)
+	}
+	if role.RoleType != models.RoleTypeNormal {
+		return nil, errors.Errorf("role with id %s isn't a normal role", c.RoleID)
+	}
+
+	roleMembersIDs, err := r.roleMembersIDs(tx, c.RoleID)
+	if err != nil {
+		return nil, err
+	}
+
+	found := false
+	for _, roleMemberID := range roleMembersIDs {
+
+		if c.MemberID == roleMemberID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, errors.Errorf("member with id %s is not a member of role %s", c.MemberID, c.RoleID)
+	}
+
+	events = append(events, eventstore.NewEventRoleMemberUpdated(c.RoleID, c.MemberID, c.Focus, c.NoCoreMember))
+
+	return events, nil
+}
+
+func (r *RolesTree) deleteRoleRecursive(tx *db.Tx, roleID util.ID, skipchilds []util.ID) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	role, err := r.role(tx, roleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, errors.Errorf("role with id %s doesn't exist", roleID)
+	}
+
+	prole, err := r.roleParent(tx, roleID)
+	if err != nil {
+		return nil, err
+	}
+	if prole == nil {
+		return nil, errors.Errorf("role with id %s doesn't have a parent", roleID)
+	}
+
+	childs, err := r.childRoles(tx, roleID)
+	if err != nil {
+		return nil, err
+	}
+
+	domains, err := r.roleDomains(tx, roleID)
+	if err != nil {
+		return nil, err
+	}
+
+	accountabilities, err := r.roleAccountabilities(tx, roleID)
+	if err != nil {
+		return nil, err
+	}
+
+	if role.RoleType == models.RoleTypeNormal {
+		// Remove role members (on normal role)
+		roleMembersIDs, err := r.roleMembersIDs(tx, roleID)
+		if err != nil {
+			return nil, err
+		}
+		for _, roleMemberID := range roleMembersIDs {
+			events = append(events, eventstore.NewEventRoleMemberRemoved(roleID, roleMemberID))
+		}
+	}
+
+	if role.RoleType == models.RoleTypeCircle {
+		// Remove circle direct members (on circle)
+		circleDirectMembersIDs, err := r.circleDirectMembersIDs(tx, roleID)
+		if err != nil {
+			return nil, err
+		}
+		for _, circleDirectMemberID := range circleDirectMembersIDs {
+			events = append(events, eventstore.NewEventCircleDirectMemberRemoved(roleID, circleDirectMemberID))
+		}
+
+		// Remove circle leadLink member
+		es, err := r.circleUnsetLeadLinkMember(tx, roleID)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, es...)
+
+		// Remove circle core roles members
+		for _, rt := range []models.RoleType{models.RoleTypeFacilitator, models.RoleTypeSecretary, models.RoleTypeRepLink} {
+			es, err := r.circleUnsetCoreRoleMember(tx, rt, roleID)
+			if err != nil {
+				return nil, err
+			}
+			events = append(events, es...)
+		}
+
+		// recursive delete for sub roles
+		for _, child := range childs {
+			// ignore childs moved to parent
+			skip := false
+			for _, cid := range skipchilds {
+				if child.ID == cid {
+					skip = true
+				}
+			}
+			if skip {
+				continue
+			}
+			es, err := r.deleteRoleRecursive(tx, child.ID, nil)
+			if err != nil {
+				return nil, err
+			}
+			events = append(events, es...)
+		}
+	}
+
+	// Remove domains from role
+	for _, domain := range domains {
+		events = append(events, eventstore.NewEventRoleDomainDeleted(roleID, domain.ID))
+	}
+
+	// Remove accountabilities from role
+	for _, accountability := range accountabilities {
+		events = append(events, eventstore.NewEventRoleAccountabilityDeleted(roleID, accountability.ID))
+	}
+
+	// First register roleDeleteEvent since its ID will be the causation ID of subsequent events
+	roleDeletedEvent := eventstore.NewEventRoleDeleted(roleID)
+	events = append(events, roleDeletedEvent)
+
+	return events, nil
+}
+
+func (r *RolesTree) roleAddCoreRoles(role *models.Role, isRootRole bool) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	for _, coreRoleDefinition := range models.GetCoreRoles() {
+		coreRole := coreRoleDefinition.Role
+
+		if isRootRole {
+			// root role doesn't have a replink
+			if coreRole.RoleType == models.RoleTypeRepLink {
+				continue
+			}
+		}
+		coreRole.ID = r.uidGenerator.UUID(fmt.Sprintf("%s-%s", role.Name, coreRole.Name))
+
+		events = append(events, eventstore.NewEventRoleCreated(coreRole, &role.ID))
+
+		domains := coreRoleDefinition.Domains
+		for _, domain := range domains {
+			domain.ID = r.uidGenerator.UUID(fmt.Sprintf("%s-%s-%s", role.Name, coreRole.Name, domain.Description))
+			events = append(events, eventstore.NewEventRoleDomainCreated(coreRole.ID, domain))
+		}
+		accountabilities := coreRoleDefinition.Accountabilities
+		for _, accountability := range accountabilities {
+			accountability.ID = r.uidGenerator.UUID(fmt.Sprintf("%s-%s-%s", role.Name, coreRole.Name, accountability.Description))
+			events = append(events, eventstore.NewEventRoleAccountabilityCreated(coreRole.ID, accountability))
+		}
+	}
+
+	return events, nil
+}
+
+func (r *RolesTree) circleUnsetLeadLinkMember(tx *db.Tx, roleID util.ID) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	leadLinkRole, err := r.circleCoreRole(tx, roleID, models.RoleTypeLeadLink)
+	if err != nil {
+		return nil, err
+	}
+
+	leadLinkMemberID, err := r.roleMembersIDs(tx, leadLinkRole.ID)
+	if err != nil {
+		return nil, err
+	}
+	if len(leadLinkMemberID) == 0 {
+		// no member assigned as lead link, don't error, just do nothing
+		return nil, nil
+	}
+
+	events = append(events, eventstore.NewEventCircleLeadLinkMemberUnset(roleID, leadLinkRole.ID, leadLinkMemberID[0]))
+
+	return events, nil
+}
+
+func (r *RolesTree) circleUnsetCoreRoleMember(tx *db.Tx, roleType models.RoleType, roleID util.ID) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	coreRole, err := r.circleCoreRole(tx, roleID, roleType)
+	if err != nil {
+		return nil, err
+	}
+
+	coreRoleMemberID, err := r.roleMembersIDs(tx, coreRole.ID)
+	if err != nil {
+		return nil, err
+	}
+	if len(coreRoleMemberID) == 0 {
+		// no member assigned to core role, don't error, just do nothing
+		return nil, nil
+	}
+
+	events = append(events, eventstore.NewEventCircleCoreRoleMemberUnset(roleID, coreRole.ID, coreRoleMemberID[0], roleType))
+
+	return events, nil
+}
+
+func (r *RolesTree) ApplyEvents(events []*eventstore.StoredEvent) error {
+	ldb, err := newDB(r.dataDir)
+	if err != nil {
+		return err
+	}
+	defer ldb.Close()
+
+	err = ldb.Do(func(tx *db.Tx) error {
+		for _, e := range events {
+			if err := r.ApplyEvent(tx, e); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return err
+}
+
+func (r *RolesTree) ApplyEvent(tx *db.Tx, event *eventstore.StoredEvent) error {
+	// skip already applied events in snapshot db
+	curVersion, err := r.curVersion(tx)
+	if err != nil {
+		return err
+	}
+	if event.Version <= curVersion {
+		return nil
+	}
+
+	log.Debugf("event: %v", event)
+
+	data, err := event.UnmarshalData()
+	if err != nil {
+		return err
+	}
+
+	r.version = event.Version
+
+	switch event.EventType {
+	case eventstore.EventTypeRoleCreated:
+		data := data.(*eventstore.EventRoleCreated)
+		role := &models.Role{
+			RoleType: data.RoleType,
+			Name:     data.Name,
+			Purpose:  data.Purpose,
+		}
+		if err := r.insertRole(tx, data.RoleID, data.ParentRoleID, role); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeRoleDeleted:
+		data := data.(*eventstore.EventRoleDeleted)
+		if err := r.deleteRole(tx, data.RoleID); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeRoleUpdated:
+		data := data.(*eventstore.EventRoleUpdated)
+		role := &models.Role{
+			RoleType: data.RoleType,
+			Name:     data.Name,
+			Purpose:  data.Purpose,
+		}
+		if err := r.updateRole(tx, data.RoleID, role); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeRoleDomainCreated:
+		data := data.(*eventstore.EventRoleDomainCreated)
+		domainID := data.DomainID
+		domain := &models.Domain{
+			Description: data.Description,
+		}
+		if err := r.insertDomain(tx, domainID, data.RoleID, domain); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeRoleDomainUpdated:
+		data := data.(*eventstore.EventRoleDomainUpdated)
+		domainID := data.DomainID
+		domain := &models.Domain{
+			Description: data.Description,
+		}
+		if err := r.updateDomain(tx, domainID, domain); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeRoleDomainDeleted:
+		data := data.(*eventstore.EventRoleDomainDeleted)
+		domainID := data.DomainID
+		if err := r.deleteDomain(tx, domainID); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeRoleAccountabilityCreated:
+		data := data.(*eventstore.EventRoleAccountabilityCreated)
+		accountabilityID := data.AccountabilityID
+		accountability := &models.Accountability{
+			Description: data.Description,
+		}
+		if err := r.insertAccountability(tx, accountabilityID, data.RoleID, accountability); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeRoleAccountabilityUpdated:
+		data := data.(*eventstore.EventRoleAccountabilityUpdated)
+		accountabilityID := data.AccountabilityID
+		accountability := &models.Accountability{
+			Description: data.Description,
+		}
+		if err := r.updateAccountability(tx, accountabilityID, accountability); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeRoleAccountabilityDeleted:
+		data := data.(*eventstore.EventRoleAccountabilityDeleted)
+		accountabilityID := data.AccountabilityID
+		if err := r.deleteAccountability(tx, accountabilityID); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeRoleAdditionalContentSet:
+
+	case eventstore.EventTypeRoleChangedParent:
+		data := data.(*eventstore.EventRoleChangedParent)
+		if err := r.changeRoleParent(tx, data.RoleID, data.ParentRoleID); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeRoleMemberAdded:
+		data := data.(*eventstore.EventRoleMemberAdded)
+		if err := r.roleAddMember(tx, data.RoleID, data.MemberID); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeRoleMemberUpdated:
+
+	case eventstore.EventTypeRoleMemberRemoved:
+		data := data.(*eventstore.EventRoleMemberRemoved)
+		if err := r.roleRemoveMember(tx, data.RoleID, data.MemberID); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeCircleDirectMemberAdded:
+		data := data.(*eventstore.EventCircleDirectMemberAdded)
+		if err := r.circleAddDirectMember(tx, data.RoleID, data.MemberID); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeCircleDirectMemberRemoved:
+		data := data.(*eventstore.EventCircleDirectMemberRemoved)
+		if err := r.circleRemoveDirectMember(tx, data.RoleID, data.MemberID); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeCircleLeadLinkMemberSet:
+		data := data.(*eventstore.EventCircleLeadLinkMemberSet)
+		if err := r.roleAddMember(tx, data.LeadLinkRoleID, data.MemberID); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeCircleLeadLinkMemberUnset:
+		data := data.(*eventstore.EventCircleLeadLinkMemberUnset)
+		if err := r.roleRemoveMember(tx, data.LeadLinkRoleID, data.MemberID); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeCircleCoreRoleMemberSet:
+		data := data.(*eventstore.EventCircleCoreRoleMemberSet)
+		if err := r.roleAddMember(tx, data.CoreRoleID, data.MemberID); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeCircleCoreRoleMemberUnset:
+		data := data.(*eventstore.EventCircleCoreRoleMemberUnset)
+		if err := r.roleRemoveMember(tx, data.CoreRoleID, data.MemberID); err != nil {
+			return err
+		}
+	}
+
+	if err := r.updateVersion(tx, event.Version); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RolesTree snapshot db
+
+var rolesTreeDBCreateStmts = []string{
+	"create table if not exists role (id uuid, parentid uuid, roletype varchar not null, name varchar, purpose varchar, PRIMARY KEY (id))",
+	"create table if not exists domain (id uuid, roleid uuid, description varchar, PRIMARY KEY (id))",
+	"create table if not exists accountability (id uuid, roleid uuid, description varchar, PRIMARY KEY (id))",
+	"create table if not exists roleadditionalcontent (id uuid, roleid uuid, content varchar, PRIMARY KEY (id))",
+	"create table if not exists circledirectmember (memberid uuid, roleid uuid)",
+	"create table if not exists rolemember (memberid uuid, roleid uuid)",
+	"create table if not exists version (version bigint)",
+}
+
+var (
+	sb = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
+
+	roleSelect = sb.Select("id", "parentid", "roletype", "name", "purpose").From("role")
+	roleInsert = sb.Insert("role").Columns("id", "parentid", "roletype", "name", "purpose")
+	roleDelete = sb.Delete("role")
+	roleUpdate = sb.Update("role")
+
+	domainSelect = sb.Select("id", "roleid", "description").From("domain")
+	domainInsert = sb.Insert("domain").Columns("id", "roleid", "description")
+	domainDelete = sb.Delete("domain")
+	domainUpdate = sb.Update("domain")
+
+	accountabilitySelect = sb.Select("id", "roleid", "description").From("accountability")
+	accountabilityInsert = sb.Insert("accountability").Columns("id", "roleid", "description")
+	accountabilityDelete = sb.Delete("accountability")
+	accountabilityUpdate = sb.Update("accountability")
+
+	roleMemberSelect = sb.Select("memberid").From("rolemember")
+	roleMemberInsert = sb.Insert("rolemember").Columns("memberid", "roleid")
+	roleMemberDelete = sb.Delete("rolemember")
+	roleMemberUpdate = sb.Update("rolemember")
+
+	circleDirectMemberSelect = sb.Select("memberid").From("circledirectmember")
+	circleDirectMemberInsert = sb.Insert("circledirectmember").Columns("memberid", "roleid")
+	circleDirectMemberDelete = sb.Delete("circledirectmember")
+	circleDirectMemberUpdate = sb.Update("circledirectmember")
+
+	versionSelect = sb.Select("version").From("version")
+	versionInsert = sb.Insert("version").Columns("version")
+	versionDelete = sb.Delete("version")
+)
+
+func (r *RolesTree) insertRole(tx *db.Tx, id util.ID, parentRoleID *util.ID, role *models.Role) error {
+	q, args, err := roleInsert.Values(id, parentRoleID, role.RoleType, role.Name, role.Purpose).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to insert role: %v", role)
+	}
+	return nil
+}
+
+func (r *RolesTree) deleteRole(tx *db.Tx, id util.ID) error {
+	q, args, err := roleDelete.Where(sq.Eq{"id": id}).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete role with id: %s", id)
+	}
+	return nil
+}
+
+func (r *RolesTree) updateRole(tx *db.Tx, id util.ID, role *models.Role) error {
+	q, args, err := roleUpdate.Where(sq.Eq{"id": id}).Set("roletype", role.RoleType).Set("name", role.Name).Set("purpose", role.Purpose).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to insert role: %v", role)
+	}
+	return nil
+}
+
+func (r *RolesTree) changeRoleParent(tx *db.Tx, id util.ID, parentID *util.ID) error {
+	q, args, err := roleUpdate.Where(sq.Eq{"id": id}).Set("parentid", parentID).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to update parent role id of role id: %s", id)
+	}
+	return nil
+}
+
+func (r *RolesTree) roleAddMember(tx *db.Tx, roleID, memberID util.ID) error {
+	q, args, err := roleMemberInsert.Values(memberID, roleID).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to insert add member id %s to role id %s", memberID, roleID)
+	}
+	return nil
+}
+
+func (r *RolesTree) roleRemoveMember(tx *db.Tx, roleID, memberID util.ID) error {
+	q, args, err := roleMemberDelete.Where(sq.Eq{"roleid": roleID, "memberid": memberID}).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete role member for roleid: %s and memberid: %s", roleID, memberID)
+	}
+	return nil
+}
+
+func (r *RolesTree) circleAddDirectMember(tx *db.Tx, roleID, memberID util.ID) error {
+	q, args, err := circleDirectMemberInsert.Values(memberID, roleID).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to insert add member id %s to role id %s", memberID, roleID)
+	}
+	return nil
+}
+
+func (r *RolesTree) circleRemoveDirectMember(tx *db.Tx, roleID, memberID util.ID) error {
+	q, args, err := circleDirectMemberDelete.Where(sq.Eq{"roleid": roleID, "memberid": memberID}).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete role member for roleid: %s and memberid: %s", roleID, memberID)
+	}
+	return nil
+}
+
+func (r *RolesTree) insertDomain(tx *db.Tx, id util.ID, roleID util.ID, domain *models.Domain) error {
+	q, args, err := domainInsert.Values(id, roleID, domain.Description).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to insert domain: %v", domain)
+	}
+	return nil
+}
+
+func (r *RolesTree) deleteDomain(tx *db.Tx, id util.ID) error {
+	q, args, err := domainDelete.Where(sq.Eq{"id": id}).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete domain with id: %s", id)
+	}
+	return nil
+}
+
+func (r *RolesTree) updateDomain(tx *db.Tx, id util.ID, domain *models.Domain) error {
+	q, args, err := domainUpdate.Where(sq.Eq{"id": id}).Set("description", domain.Description).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to insert domain: %v", domain)
+	}
+	return nil
+}
+
+func (r *RolesTree) insertAccountability(tx *db.Tx, id util.ID, roleID util.ID, accountability *models.Accountability) error {
+	q, args, err := accountabilityInsert.Values(id, roleID, accountability.Description).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to insert accountability: %v", accountability)
+	}
+	return nil
+}
+
+func (r *RolesTree) deleteAccountability(tx *db.Tx, id util.ID) error {
+	q, args, err := accountabilityDelete.Where(sq.Eq{"id": id}).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete accountability with id: %s", id)
+	}
+	return nil
+}
+
+func (r *RolesTree) updateAccountability(tx *db.Tx, id util.ID, accountability *models.Accountability) error {
+	q, args, err := accountabilityUpdate.Where(sq.Eq{"id": id}).Set("description", accountability.Description).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to insert accountability: %v", accountability)
+	}
+	return nil
+}
+
+func (r *RolesTree) updateVersion(tx *db.Tx, version int64) error {
+	q, args, err := versionDelete.ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete version: %v", version)
+	}
+
+	q, args, err = versionInsert.Values(version).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to insert version: %v", version)
+	}
+	return nil
+}
+
+// Queries
+
+func (r *RolesTree) curVersion(tx *db.Tx) (int64, error) {
+	var version int64
+	err := tx.Do(func(tx *db.WrappedTx) error {
+		return tx.QueryRow("select version from version limit 1").Scan(&version)
+	})
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return version, nil
+}
+
+func (r *RolesTree) role(tx *db.Tx, roleID util.ID) (*models.Role, error) {
+	q, args, err := roleSelect.Where(sq.Eq{"id": roleID}).ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build query")
+	}
+
+	role := models.Role{}
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		// To make sqlite3 happy
+		var roleType string
+		var parentID *util.ID
+		row := tx.QueryRow(q, args...)
+		if err := row.Scan(&role.ID, &parentID, &roleType, &role.Name, &role.Purpose); err != nil {
+			return err
+		}
+		role.RoleType = models.RoleType(roleType)
+		return nil
+	})
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to query role: %v", role)
+	}
+	return &role, nil
+}
+
+func (r *RolesTree) roleParent(tx *db.Tx, roleID util.ID) (*models.Role, error) {
+	role, err := r.role(tx, roleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, nil
+	}
+	return r.role(tx, role.ID)
+}
+
+func (r *RolesTree) rootRole(tx *db.Tx) (*models.Role, error) {
+	q, args, err := roleSelect.Where(sq.Eq{"parentid": nil}).ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build query")
+	}
+
+	role := models.Role{}
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		// To make sqlite3 happy
+		var roleType string
+		var parentID *util.ID
+		row := tx.QueryRow(q, args...)
+		if err := row.Scan(&role.ID, &parentID, &roleType, &role.Name, &role.Purpose); err != nil {
+			return err
+		}
+		role.RoleType = models.RoleType(roleType)
+		return nil
+	})
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to query root role: %v", role)
+	}
+	return &role, nil
+}
+
+func (r *RolesTree) childRoles(tx *db.Tx, roleID util.ID) ([]*models.Role, error) {
+	q, args, err := roleSelect.Where(sq.Eq{"parentid": roleID}).ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build query")
+	}
+
+	roles := []*models.Role{}
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		rows, err := tx.Query(q, args...)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute query")
+		}
+		for rows.Next() {
+			role := models.Role{}
+			// To make sqlite3 happy
+			var roleType string
+			var parentID util.ID
+			if err := rows.Scan(&role.ID, &parentID, &roleType, &role.Name, &role.Purpose); err != nil {
+				return errors.Wrap(err, "failed to scan rows")
+			}
+			role.RoleType = models.RoleType(roleType)
+			if err != nil {
+				rows.Close()
+				return err
+			}
+			roles = append(roles, &role)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to query child role for role with id: %s", roleID)
+	}
+	return roles, nil
+}
+
+func (r *RolesTree) circleCoreRole(tx *db.Tx, roleID util.ID, roleType models.RoleType) (*models.Role, error) {
+	log.Debugf("roleid: %s, roleType: %s", roleID, roleType)
+	q, args, err := roleSelect.Where(sq.Eq{"parentid": roleID, "roletype": roleType}).ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build query")
+	}
+
+	role := models.Role{}
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		// To make sqlite3 happy
+		var roleType string
+		var parentID *util.ID
+		row := tx.QueryRow(q, args...)
+		if err := row.Scan(&role.ID, &parentID, &roleType, &role.Name, &role.Purpose); err != nil {
+			return err
+		}
+		role.RoleType = models.RoleType(roleType)
+		return nil
+	})
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to query circle core role: %v", role)
+	}
+	return &role, nil
+}
+
+func (r *RolesTree) roleMembersIDs(tx *db.Tx, roleID util.ID) ([]util.ID, error) {
+	q, args, err := roleMemberSelect.Where(sq.Eq{"roleid": roleID}).ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build query")
+	}
+
+	members := []util.ID{}
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		rows, err := tx.Query(q, args...)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute query")
+		}
+		for rows.Next() {
+			member := util.ID{}
+			if err := rows.Scan(&member); err != nil {
+				return errors.Wrap(err, "failed to scan rows")
+			}
+			if err != nil {
+				rows.Close()
+				return err
+			}
+			members = append(members, member)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to query members for role with id: %s", roleID)
+	}
+	return members, nil
+}
+
+func (r *RolesTree) circleDirectMembersIDs(tx *db.Tx, roleID util.ID) ([]util.ID, error) {
+	q, args, err := circleDirectMemberSelect.Where(sq.Eq{"roleid": roleID}).ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build query")
+	}
+
+	members := []util.ID{}
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		rows, err := tx.Query(q, args...)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute query")
+		}
+		for rows.Next() {
+			member := util.ID{}
+			if err := rows.Scan(&member); err != nil {
+				return errors.Wrap(err, "failed to scan rows")
+			}
+			if err != nil {
+				rows.Close()
+				return err
+			}
+			members = append(members, member)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to query members for role with id: %s", roleID)
+	}
+	return members, nil
+}
+
+func (r *RolesTree) roleDomains(tx *db.Tx, roleID util.ID) ([]*models.Domain, error) {
+	q, args, err := domainSelect.Where(sq.Eq{"roleid": roleID}).ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build query")
+	}
+
+	domains := []*models.Domain{}
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		rows, err := tx.Query(q, args...)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute query")
+		}
+		for rows.Next() {
+			domain := models.Domain{}
+			var roleID util.ID
+			if err := rows.Scan(&domain.ID, &roleID, &domain.Description); err != nil {
+				return errors.Wrap(err, "failed to scan rows")
+			}
+			if err != nil {
+				rows.Close()
+				return err
+			}
+			domains = append(domains, &domain)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to query domains for role with id: %s", roleID)
+	}
+	return domains, nil
+}
+
+func (r *RolesTree) roleAccountabilities(tx *db.Tx, roleID util.ID) ([]*models.Accountability, error) {
+	q, args, err := accountabilitySelect.Where(sq.Eq{"roleid": roleID}).ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build query")
+	}
+
+	accountabilities := []*models.Accountability{}
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		rows, err := tx.Query(q, args...)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute query")
+		}
+		for rows.Next() {
+			accountability := models.Accountability{}
+			var roleID util.ID
+			if err := rows.Scan(&accountability.ID, &roleID, &accountability.Description); err != nil {
+				return errors.Wrap(err, "failed to scan rows")
+			}
+			if err != nil {
+				rows.Close()
+				return err
+			}
+			accountabilities = append(accountabilities, &accountability)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to query accountabilities for role with id: %s", roleID)
+	}
+	return accountabilities, nil
+}
+
+func (r *RolesTree) CheckBrokenEdges(tx *db.Tx) error {
+	getIDs := func(q string, args []interface{}) ([]*util.ID, error) {
+		ids := []*util.ID{}
+		err := tx.Do(func(tx *db.WrappedTx) error {
+			rows, err := tx.Query(q, args...)
+			if err != nil {
+				return errors.Wrap(err, "failed to execute query")
+			}
+			for rows.Next() {
+				var id util.ID
+				if err := rows.Scan(&id); err != nil {
+					rows.Close()
+					return errors.Wrap(err, "failed to scan rows")
+				}
+				ids = append(ids, &id)
+			}
+			if err := rows.Err(); err != nil {
+				return err
+			}
+			return nil
+		})
+		return ids, err
+	}
+
+	// check broken child/parents: query roles without a parent
+	q, args, err := sb.Select("r1.id").From("role r1").LeftJoin("role r2 on r1.parentid = r2.id where r2.id is null").ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	ids, err := getIDs(q, args)
+	if err != nil {
+		return err
+	}
+	// len shold be one (the root role doesn't have a parent
+	if len(ids) > 1 {
+		return errors.Errorf("there are %d broken roles", len(ids)-1)
+	}
+
+	type check struct {
+		table    string
+		sourceID string
+	}
+
+	checks := []check{
+		{
+			table:    "domain",
+			sourceID: "id",
+		},
+		{
+			table:    "accountability",
+			sourceID: "id",
+		},
+		{
+			table:    "rolemember",
+			sourceID: "memberid",
+		},
+		{
+			table:    "circledirectmember",
+			sourceID: "memberid",
+		},
+	}
+
+	// check broken relations: query relations to a non existing role
+	for _, c := range checks {
+		q, args, err = sb.Select("t." + c.sourceID).From(fmt.Sprintf("%s as t", c.table)).LeftJoin("role r on t.roleid = r.id where r.id is null").ToSql()
+		if err != nil {
+			return errors.Wrap(err, "failed to build query")
+		}
+
+		ids, err := getIDs(q, args)
+		if err != nil {
+			return err
+		}
+		if len(ids) > 0 {
+			return errors.Errorf("there are %d broken %s", len(ids), c.table)
+		}
+	}
+
+	return nil
+}

--- a/aggregate/rolestree_test.go
+++ b/aggregate/rolestree_test.go
@@ -1,0 +1,396 @@
+package aggregate
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/sorintlab/sircles/change"
+	"github.com/sorintlab/sircles/command/commands"
+	"github.com/sorintlab/sircles/eventstore"
+	"github.com/sorintlab/sircles/util"
+)
+
+func idP(id util.ID) *util.ID {
+	return &id
+}
+
+func TestSetupRootRole(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	uidGenerator := NewTestUIDGen()
+
+	correlationID := uidGenerator.UUID("")
+	causationID := uidGenerator.UUID("")
+
+	aggregate, err := NewRolesTree(tmpDir, uidGenerator, eventstore.RolesTreeAggregateID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rootRoleID := uidGenerator.UUID("General")
+
+	command := commands.NewCommand(commands.CommandTypeSetupRootRole, correlationID, causationID, util.NilID, &commands.SetupRootRole{
+		RootRoleID: rootRoleID,
+		Name:       "General",
+	})
+
+	out := []eventstore.Event{
+		&eventstore.EventRoleCreated{
+			RoleID:       rootRoleID,
+			RoleType:     "circle",
+			Name:         "General",
+			Purpose:      "",
+			ParentRoleID: nil,
+		},
+		&eventstore.EventRoleCreated{
+			RoleID:       util.IDFromStringOrNil("bbaf4d08-0263-585c-86ab-7e68b97df0aa"),
+			RoleType:     "leadlink",
+			Name:         "Lead Link",
+			Purpose:      "The Lead Link holds the Purpose of the overall Circle",
+			ParentRoleID: idP(util.IDFromStringOrNil("647d8c4d-b4db-5709-9d36-b6ee28cbbd93")),
+		},
+		&eventstore.EventRoleDomainCreated{
+			DomainID:    util.IDFromStringOrNil("044a5b53-e740-52ae-a121-f80bc727808c"),
+			RoleID:      util.IDFromStringOrNil("bbaf4d08-0263-585c-86ab-7e68b97df0aa"),
+			Description: "Role assignments within the Circle",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("4fe52656-283d-5df8-b101-981fa37775a7"),
+			RoleID:           util.IDFromStringOrNil("bbaf4d08-0263-585c-86ab-7e68b97df0aa"),
+			Description:      "Structuring the Governance of the Circle to enact its Purpose and Accountabilities",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("285af64e-1f6d-56ed-95ca-793d68bccb6d"),
+			RoleID:           util.IDFromStringOrNil("bbaf4d08-0263-585c-86ab-7e68b97df0aa"),
+			Description:      "Assigning Partners to the Circle’s Roles; monitoring the fit; offering feedback to enhance fit; and re-assigning Roles to other Partners when useful for enhancing fit",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("25009f9f-a478-5739-830f-2011c7601c5b"),
+			RoleID:           util.IDFromStringOrNil("bbaf4d08-0263-585c-86ab-7e68b97df0aa"),
+			Description:      "Allocating the Circle’s resources across its various Projects and/or Roles",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("f6c43457-9ca0-5c65-876a-8a2019f51a74"),
+			RoleID:           util.IDFromStringOrNil("bbaf4d08-0263-585c-86ab-7e68b97df0aa"),
+			Description:      "Establishing priorities and Strategies for the Circle",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("6c81b1c9-dc1e-56e2-964b-0b9008ee89db"),
+			RoleID:           util.IDFromStringOrNil("bbaf4d08-0263-585c-86ab-7e68b97df0aa"),
+			Description:      "Defining metrics for the circle",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("f6c5746a-786e-5d5b-b5ff-ab667830df6a"),
+			RoleID:           util.IDFromStringOrNil("bbaf4d08-0263-585c-86ab-7e68b97df0aa"),
+			Description:      "Removing constraints within the Circle to the Super-Circle enacting its Purpose and Accountabilities",
+		},
+		&eventstore.EventRoleCreated{
+			RoleID:       util.IDFromStringOrNil("12accb8f-657c-53f8-9571-0fb44734c07b"),
+			RoleType:     "facilitator",
+			Name:         "Facilitator",
+			Purpose:      "Circle governance and operational practices aligned with the Constitution",
+			ParentRoleID: idP(util.IDFromStringOrNil("647d8c4d-b4db-5709-9d36-b6ee28cbbd93")),
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("a2f866f6-060f-5da4-a50e-91d542cc7b34"),
+			RoleID:           util.IDFromStringOrNil("12accb8f-657c-53f8-9571-0fb44734c07b"),
+			Description:      "Facilitating the Circle’s constitutionally-required meetings",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("6ccaa4ae-87a2-5365-b898-f4176395c59d"),
+			RoleID:           util.IDFromStringOrNil("12accb8f-657c-53f8-9571-0fb44734c07b"),
+			Description:      "Auditing the meetings and records of Sub-Circles as needed, and declaring a Process Breakdown upon discovering a pattern of behavior that conflicts with the rules of the Constitution",
+		},
+		&eventstore.EventRoleCreated{
+			RoleID:       util.IDFromStringOrNil("f0bad79e-3320-5889-ae8e-106ee6b0ce14"),
+			RoleType:     "secretary",
+			Name:         "Secretary",
+			Purpose:      "Steward and stabilize the Circle’s formal records and record-keeping process",
+			ParentRoleID: idP(util.IDFromStringOrNil("647d8c4d-b4db-5709-9d36-b6ee28cbbd93")),
+		},
+		&eventstore.EventRoleDomainCreated{
+			DomainID:    util.IDFromStringOrNil("45861d2f-35fa-59b1-951f-ffe321a581ea"),
+			RoleID:      util.IDFromStringOrNil("f0bad79e-3320-5889-ae8e-106ee6b0ce14"),
+			Description: "All constitutionally-required records of the Circle",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("51c14074-0ec2-5ab1-bdd7-9786663b7ec4"),
+			RoleID:           util.IDFromStringOrNil("f0bad79e-3320-5889-ae8e-106ee6b0ce14"),
+			Description:      "Scheduling the Circle’s required meetings, and notifying all Core Circle Members of scheduled times and locations",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("fc0cac54-8c20-5717-8cd6-0a0138b2efd0"),
+			RoleID:           util.IDFromStringOrNil("f0bad79e-3320-5889-ae8e-106ee6b0ce14"),
+			Description:      "Capturing and publishing the outputs of the Circle’s required meetings, and maintaining a compiled view of the Circle’s current Governance, checklist items, and metrics",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("ea00a95f-23dc-5652-81df-84f7e2670c75"),
+			RoleID:           util.IDFromStringOrNil("f0bad79e-3320-5889-ae8e-106ee6b0ce14"),
+			Description:      "Interpreting Governance and the Constitution upon request",
+		},
+	}
+
+	test := &testData{
+		Aggregate: aggregate,
+		Command:   command,
+		Out:       out,
+	}
+
+	runTest(t, test)
+}
+
+func setupRolesTree(t *testing.T) []*eventstore.StoredEvent {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	uidGenerator := NewTestUIDGen()
+
+	correlationID := uidGenerator.UUID("")
+	causationID := uidGenerator.UUID("")
+
+	aggregate, err := NewRolesTree(tmpDir, uidGenerator, eventstore.RolesTreeAggregateID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rootRoleID := uidGenerator.UUID("General")
+
+	command := commands.NewCommand(commands.CommandTypeSetupRootRole, correlationID, causationID, util.NilID, &commands.SetupRootRole{
+		RootRoleID: rootRoleID,
+		Name:       "General",
+	})
+
+	out, err := aggregate.HandleCommand(command)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	storedEvents, err := toStoredEvents(out, aggregate.AggregateType(), aggregate.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	return storedEvents
+}
+
+// Create a new child role of type normal
+func TestCircleCreateChildRole1(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	storedEvents := setupRolesTree(t)
+
+	uidGenerator := NewTestUIDGen()
+
+	correlationID := uidGenerator.UUID("")
+	causationID := uidGenerator.UUID("")
+
+	rootRoleID := uidGenerator.UUID("General")
+	newRoleID := uidGenerator.UUID("role01")
+
+	command := commands.NewCommand(commands.CommandTypeCircleCreateChildRole, correlationID, causationID, util.NilID, &commands.CircleCreateChildRole{
+		RoleID:    rootRoleID,
+		NewRoleID: newRoleID,
+		CreateRoleChange: change.CreateRoleChange{
+			RoleType: "normal",
+			Name:     "role01",
+			Purpose:  "purpose",
+		},
+	})
+
+	aggregate, err := NewRolesTree(tmpDir, uidGenerator, eventstore.RolesTreeAggregateID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := []eventstore.Event{
+		&eventstore.EventRoleCreated{
+			RoleID:       newRoleID,
+			RoleType:     "normal",
+			Name:         "role01",
+			Purpose:      "purpose",
+			ParentRoleID: &rootRoleID,
+		},
+	}
+
+	test := &testData{
+		State:     storedEvents,
+		Aggregate: aggregate,
+		Command:   command,
+		Out:       out,
+	}
+
+	runTest(t, test)
+}
+
+// Create a new child role of type circle
+func TestCircleCreateChildRole2(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	storedEvents := setupRolesTree(t)
+
+	uidGenerator := NewTestUIDGen()
+
+	correlationID := uidGenerator.UUID("")
+	causationID := uidGenerator.UUID("")
+
+	rootRoleID := uidGenerator.UUID("General")
+	newRoleID := uidGenerator.UUID("role01")
+
+	command := commands.NewCommand(commands.CommandTypeCircleCreateChildRole, correlationID, causationID, util.NilID, &commands.CircleCreateChildRole{
+		RoleID:    rootRoleID,
+		NewRoleID: newRoleID,
+		CreateRoleChange: change.CreateRoleChange{
+			RoleType: "circle",
+			Name:     "role01",
+			Purpose:  "purpose",
+		},
+	})
+
+	aggregate, err := NewRolesTree(tmpDir, uidGenerator, eventstore.RolesTreeAggregateID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := []eventstore.Event{
+		&eventstore.EventRoleCreated{
+			RoleID:       newRoleID,
+			RoleType:     "circle",
+			Name:         "role01",
+			Purpose:      "purpose",
+			ParentRoleID: &rootRoleID,
+		},
+		&eventstore.EventRoleCreated{
+			RoleID:       util.IDFromStringOrNil("d5a65242-40db-554c-a165-93dcb9ba7ab8"),
+			RoleType:     "leadlink",
+			Name:         "Lead Link",
+			Purpose:      "The Lead Link holds the Purpose of the overall Circle",
+			ParentRoleID: idP(util.IDFromStringOrNil("cf981be4-885a-55e7-907d-b1ecbe3a5893")),
+		},
+		&eventstore.EventRoleDomainCreated{
+			DomainID:    util.IDFromStringOrNil("a2813ae2-f5c0-512f-9597-179cfea5fad2"),
+			RoleID:      util.IDFromStringOrNil("d5a65242-40db-554c-a165-93dcb9ba7ab8"),
+			Description: "Role assignments within the Circle",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("d8faf006-e148-5a42-aab3-7d4dbf9beb74"),
+			RoleID:           util.IDFromStringOrNil("d5a65242-40db-554c-a165-93dcb9ba7ab8"),
+			Description:      "Structuring the Governance of the Circle to enact its Purpose and Accountabilities",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("35138db6-b54f-58a4-bafb-75f3546eda5c"),
+			RoleID:           util.IDFromStringOrNil("d5a65242-40db-554c-a165-93dcb9ba7ab8"),
+			Description:      "Assigning Partners to the Circle’s Roles; monitoring the fit; offering feedback to enhance fit; and re-assigning Roles to other Partners when useful for enhancing fit",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("ba4c059b-6b29-5cf1-bef0-a5d04bd55c6b"),
+			RoleID:           util.IDFromStringOrNil("d5a65242-40db-554c-a165-93dcb9ba7ab8"),
+			Description:      "Allocating the Circle’s resources across its various Projects and/or Roles",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("a3cff008-ba9d-5df2-bf50-4c5466dd9521"),
+			RoleID:           util.IDFromStringOrNil("d5a65242-40db-554c-a165-93dcb9ba7ab8"),
+			Description:      "Establishing priorities and Strategies for the Circle",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("256a7b1f-2d90-5a31-9dba-7b1fb7ec2322"),
+			RoleID:           util.IDFromStringOrNil("d5a65242-40db-554c-a165-93dcb9ba7ab8"),
+			Description:      "Defining metrics for the circle",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("0b00825a-e0ea-5390-a2fc-b80eddb13d6f"),
+			RoleID:           util.IDFromStringOrNil("d5a65242-40db-554c-a165-93dcb9ba7ab8"),
+			Description:      "Removing constraints within the Circle to the Super-Circle enacting its Purpose and Accountabilities",
+		},
+		&eventstore.EventRoleCreated{
+			RoleID:       util.IDFromStringOrNil("a4eb2708-d1e8-5cb3-8c3a-81e03e16a7c7"),
+			RoleType:     "replink",
+			Name:         "Rep Link",
+			Purpose:      "Within the Super-Circle, the Rep Link holds the Purpose of the SubCircle; within the Sub-Circle, the Rep Link’s Purpose is: Tensions relevant to process in the Super-Circle channeled out and resolved",
+			ParentRoleID: idP(util.IDFromStringOrNil("cf981be4-885a-55e7-907d-b1ecbe3a5893")),
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("e3cf8705-6977-5d40-99f8-cac4966a1256"),
+			RoleID:           util.IDFromStringOrNil("a4eb2708-d1e8-5cb3-8c3a-81e03e16a7c7"),
+			Description:      "Removing constraints within the broader Organization that limit the Sub-Circle",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("d1234b76-3065-5c85-9e04-ba8cb06410aa"),
+			RoleID:           util.IDFromStringOrNil("a4eb2708-d1e8-5cb3-8c3a-81e03e16a7c7"),
+			Description:      "Seeking to understand Tensions conveyed by Sub-Circle Circle Members, and discerning those appropriate to process in the Super-Circle",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("356c72cf-4ac9-5811-bd94-fda0ff20f945"),
+			RoleID:           util.IDFromStringOrNil("a4eb2708-d1e8-5cb3-8c3a-81e03e16a7c7"),
+			Description:      "Providing visibility to the Super-Circle into the health of the Sub-Circle, including reporting on any metrics or checklist items assigned to the whole Sub-Circle",
+		},
+		&eventstore.EventRoleCreated{
+			RoleID:       util.IDFromStringOrNil("47f84493-cfdd-579a-8315-7fc8163de530"),
+			RoleType:     "facilitator",
+			Name:         "Facilitator",
+			Purpose:      "Circle governance and operational practices aligned with the Constitution",
+			ParentRoleID: idP(util.IDFromStringOrNil("cf981be4-885a-55e7-907d-b1ecbe3a5893")),
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("7a6a47cd-9ea9-5ab4-b467-76d0ddd3a438"),
+			RoleID:           util.IDFromStringOrNil("47f84493-cfdd-579a-8315-7fc8163de530"),
+			Description:      "Facilitating the Circle’s constitutionally-required meetings",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("7681fc95-5fe7-5651-aab1-7ea86abd47fb"),
+			RoleID:           util.IDFromStringOrNil("47f84493-cfdd-579a-8315-7fc8163de530"),
+			Description:      "Auditing the meetings and records of Sub-Circles as needed, and declaring a Process Breakdown upon discovering a pattern of behavior that conflicts with the rules of the Constitution",
+		},
+		&eventstore.EventRoleCreated{
+			RoleID:       util.IDFromStringOrNil("f772dfc8-28cd-5f04-91bc-15712f2613de"),
+			RoleType:     "secretary",
+			Name:         "Secretary",
+			Purpose:      "Steward and stabilize the Circle’s formal records and record-keeping process",
+			ParentRoleID: idP(util.IDFromStringOrNil("cf981be4-885a-55e7-907d-b1ecbe3a5893")),
+		},
+		&eventstore.EventRoleDomainCreated{
+			DomainID:    util.IDFromStringOrNil("bc9fe26e-6c68-5675-ad4e-232c8ecf0eb5"),
+			RoleID:      util.IDFromStringOrNil("f772dfc8-28cd-5f04-91bc-15712f2613de"),
+			Description: "All constitutionally-required records of the Circle",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("e2afc9c0-6f7a-511c-aa59-6aa2ede3bac8"),
+			RoleID:           util.IDFromStringOrNil("f772dfc8-28cd-5f04-91bc-15712f2613de"),
+			Description:      "Scheduling the Circle’s required meetings, and notifying all Core Circle Members of scheduled times and locations",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("e070246c-df7f-584e-88ee-8280c33c8fab"),
+			RoleID:           util.IDFromStringOrNil("f772dfc8-28cd-5f04-91bc-15712f2613de"),
+			Description:      "Capturing and publishing the outputs of the Circle’s required meetings, and maintaining a compiled view of the Circle’s current Governance, checklist items, and metrics",
+		},
+		&eventstore.EventRoleAccountabilityCreated{
+			AccountabilityID: util.IDFromStringOrNil("ca7e1d84-f480-5ca4-8807-14e1c6e60649"),
+			RoleID:           util.IDFromStringOrNil("f772dfc8-28cd-5f04-91bc-15712f2613de"),
+			Description:      "Interpreting Governance and the Constitution upon request",
+		},
+	}
+
+	test := &testData{
+		State:     storedEvents,
+		Aggregate: aggregate,
+		Command:   command,
+		Out:       out,
+	}
+
+	runTest(t, test)
+}

--- a/aggregate/tension.go
+++ b/aggregate/tension.go
@@ -1,0 +1,210 @@
+package aggregate
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/sorintlab/sircles/command/commands"
+	"github.com/sorintlab/sircles/common"
+	"github.com/sorintlab/sircles/eventstore"
+	"github.com/sorintlab/sircles/models"
+	"github.com/sorintlab/sircles/util"
+)
+
+type TensionRepository struct {
+	es           *eventstore.EventStore
+	uidGenerator common.UIDGenerator
+}
+
+func NewTensionRepository(es *eventstore.EventStore, uidGenerator common.UIDGenerator) *TensionRepository {
+	return &TensionRepository{es: es, uidGenerator: uidGenerator}
+}
+
+func (tr *TensionRepository) Load(id util.ID) (*Tension, error) {
+	log.Debugf("Load id: %s", id)
+	t := NewTension(tr.uidGenerator, id)
+
+	if err := batchLoader(tr.es, id.String(), t); err != nil {
+		return nil, err
+	}
+
+	return t, nil
+}
+
+type Tension struct {
+	id      util.ID
+	version int64
+
+	title       string
+	description string
+	roleID      *util.ID
+
+	created      bool
+	uidGenerator common.UIDGenerator
+}
+
+func NewTension(uidGenerator common.UIDGenerator, id util.ID) *Tension {
+	return &Tension{
+		id:           id,
+		uidGenerator: uidGenerator,
+	}
+}
+
+func (t *Tension) Version() int64 {
+	return t.version
+}
+
+func (t *Tension) ID() string {
+	return t.id.String()
+}
+
+func (t *Tension) AggregateType() eventstore.AggregateType {
+	return eventstore.TensionAggregate
+}
+
+func (t *Tension) HandleCommand(command *commands.Command) ([]eventstore.Event, error) {
+	var events []eventstore.Event
+	var err error
+	switch command.CommandType {
+	case commands.CommandTypeCreateTension:
+		events, err = t.HandleCreateTensionCommand(command)
+	case commands.CommandTypeUpdateTension:
+		events, err = t.HandleUpdateTensionCommand(command)
+	case commands.CommandTypeChangeTensionRole:
+		events, err = t.HandleChangeTensionRoleCommand(command)
+	case commands.CommandTypeCloseTension:
+		events, err = t.HandleCloseTensionCommand(command)
+
+	default:
+		err = fmt.Errorf("unhandled command: %#v", command)
+	}
+
+	return events, err
+}
+
+func (t *Tension) HandleCreateTensionCommand(command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.CreateTension)
+
+	tension := &models.Tension{
+		Title:       c.Title,
+		Description: c.Description,
+	}
+	tension.ID = t.id
+
+	events = append(events, eventstore.NewEventTensionCreated(tension, c.MemberID, c.RoleID))
+
+	return events, nil
+}
+
+func (t *Tension) HandleUpdateTensionCommand(command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	if !t.created {
+		return nil, errors.New("unexistent tension")
+	}
+
+	c := command.Data.(*commands.UpdateTension)
+
+	tension := &models.Tension{
+		Title:       c.Title,
+		Description: c.Description,
+	}
+	tension.ID = t.id
+
+	roleChanged := false
+	prevRoleID := t.roleID
+	if t.roleID != nil && c.RoleID != nil {
+		if *t.roleID != *c.RoleID {
+			roleChanged = true
+		}
+	}
+	if t.roleID == nil && c.RoleID != nil || t.roleID != nil && c.RoleID == nil {
+		roleChanged = true
+	}
+	if roleChanged {
+		events = append(events, eventstore.NewEventTensionRoleChanged(tension.ID, prevRoleID, c.RoleID))
+	}
+
+	events = append(events, eventstore.NewEventTensionUpdated(tension))
+
+	return events, nil
+}
+
+func (t *Tension) HandleChangeTensionRoleCommand(command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.ChangeTensionRole)
+
+	// if a version is provided then execute the command only if it matched the
+	// current tension's version
+	if c.TensionVersion != 0 {
+		if c.TensionVersion != t.version {
+			return nil, nil
+		}
+	}
+
+	prevRoleID := t.roleID
+
+	events = append(events, eventstore.NewEventTensionRoleChanged(t.id, prevRoleID, c.RoleID))
+
+	return events, nil
+}
+
+func (t *Tension) HandleCloseTensionCommand(command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.CloseTension)
+
+	events = append(events, eventstore.NewEventTensionClosed(t.id, c.Reason))
+
+	return events, nil
+}
+
+func (t *Tension) ApplyEvents(events []*eventstore.StoredEvent) error {
+	for _, e := range events {
+		if err := t.ApplyEvent(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *Tension) ApplyEvent(event *eventstore.StoredEvent) error {
+	log.Debugf("event: %v", event)
+
+	data, err := event.UnmarshalData()
+	if err != nil {
+		return err
+	}
+
+	t.version = event.Version
+
+	switch event.EventType {
+	case eventstore.EventTypeTensionCreated:
+		data := data.(*eventstore.EventTensionCreated)
+
+		t.title = data.Title
+		t.description = data.Description
+		t.roleID = data.RoleID
+
+		t.created = true
+
+	case eventstore.EventTypeTensionUpdated:
+		data := data.(*eventstore.EventTensionUpdated)
+
+		t.title = data.Title
+		t.description = data.Description
+
+	case eventstore.EventTypeTensionRoleChanged:
+		data := data.(*eventstore.EventTensionRoleChanged)
+
+		t.roleID = data.RoleID
+
+	case eventstore.EventTypeTensionClosed:
+
+	}
+
+	return nil
+}

--- a/aggregate/tension_test.go
+++ b/aggregate/tension_test.go
@@ -1,0 +1,151 @@
+package aggregate
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sorintlab/sircles/command/commands"
+	"github.com/sorintlab/sircles/eventstore"
+	"github.com/sorintlab/sircles/util"
+)
+
+func TestCreateTension(t *testing.T) {
+	uidGenerator := NewTestUIDGen()
+
+	tensionID := uidGenerator.UUID("")
+	memberID := uidGenerator.UUID("")
+
+	correlationID := uidGenerator.UUID("")
+	causationID := uidGenerator.UUID("")
+
+	aggregate := NewTension(uidGenerator, tensionID)
+
+	command := commands.NewCommand(commands.CommandTypeCreateTension, correlationID, causationID, util.NilID, &commands.CreateTension{
+		Title:       "tension01",
+		Description: "Tension 01",
+		MemberID:    memberID,
+		RoleID:      nil,
+	})
+
+	out := []eventstore.Event{
+		&eventstore.EventTensionCreated{
+			Title:       "tension01",
+			Description: "Tension 01",
+			MemberID:    memberID,
+			RoleID:      nil,
+		},
+	}
+
+	test := &testData{
+		Aggregate: aggregate,
+		Command:   command,
+		Out:       out,
+	}
+
+	runTest(t, test)
+}
+
+func setupTension(t *testing.T, tensionID util.ID) []*eventstore.StoredEvent {
+	uidGenerator := NewTestUIDGen()
+
+	memberID := uidGenerator.UUID("")
+
+	correlationID := uidGenerator.UUID("")
+	causationID := uidGenerator.UUID("")
+
+	aggregate := NewTension(uidGenerator, tensionID)
+
+	command := commands.NewCommand(commands.CommandTypeCreateTension, correlationID, causationID, util.NilID, &commands.CreateTension{
+		Title:       "tension01",
+		Description: "Tension 01",
+		MemberID:    memberID,
+		RoleID:      nil,
+	})
+
+	out := []eventstore.Event{
+		&eventstore.EventTensionCreated{
+			Title:       "tension01",
+			Description: "Tension 01",
+			MemberID:    memberID,
+			RoleID:      nil,
+		},
+	}
+
+	out, err := aggregate.HandleCommand(command)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	storedEvents, err := toStoredEvents(out, aggregate.AggregateType(), aggregate.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	return storedEvents
+}
+
+func TestUpdateTension(t *testing.T) {
+	uidGenerator := NewTestUIDGen()
+
+	tensionID := uidGenerator.UUID("")
+	storedEvents := setupTension(t, tensionID)
+
+	correlationID := uidGenerator.UUID("")
+	causationID := uidGenerator.UUID("")
+
+	aggregate := NewTension(uidGenerator, tensionID)
+
+	command := commands.NewCommand(commands.CommandTypeUpdateTension, correlationID, causationID, util.NilID, &commands.UpdateTension{
+		Title:       "tension 01 new title",
+		Description: "Tension 01 new description",
+	})
+
+	out := []eventstore.Event{
+		&eventstore.EventTensionUpdated{
+			Title:       "tension 01 new title",
+			Description: "Tension 01 new description",
+		},
+	}
+
+	test := &testData{
+		State:     storedEvents,
+		Aggregate: aggregate,
+		Command:   command,
+		Out:       out,
+	}
+
+	runTest(t, test)
+}
+
+func TestUpdateNotExistingTension(t *testing.T) {
+	uidGenerator := NewTestUIDGen()
+
+	// update a not existings tension
+	tensionID := uidGenerator.UUID("")
+
+	correlationID := uidGenerator.UUID("")
+	causationID := uidGenerator.UUID("")
+
+	aggregate := NewTension(uidGenerator, tensionID)
+
+	command := commands.NewCommand(commands.CommandTypeUpdateTension, correlationID, causationID, util.NilID, &commands.UpdateTension{
+		Title:       "tension 01 new title",
+		Description: "Tension 01 new description",
+	})
+
+	out := []eventstore.Event{
+		&eventstore.EventTensionUpdated{
+			Title:       "tension 01 new title",
+			Description: "Tension 01 new description",
+		},
+	}
+
+	test := &testData{
+		Aggregate: aggregate,
+		Command:   command,
+		Out:       out,
+		Err:       fmt.Errorf("unexistent tension"),
+	}
+
+	runTest(t, test)
+}

--- a/aggregate/uniquevalueregistry.go
+++ b/aggregate/uniquevalueregistry.go
@@ -1,0 +1,160 @@
+package aggregate
+
+import (
+	"fmt"
+
+	"github.com/sorintlab/sircles/command/commands"
+	"github.com/sorintlab/sircles/common"
+	"github.com/sorintlab/sircles/eventstore"
+	"github.com/sorintlab/sircles/util"
+)
+
+type UniqueValueRegistryRepository struct {
+	es           *eventstore.EventStore
+	uidGenerator common.UIDGenerator
+}
+
+func NewUniqueValueRegistryRepository(es *eventstore.EventStore, uidGenerator common.UIDGenerator) *UniqueValueRegistryRepository {
+	return &UniqueValueRegistryRepository{es: es, uidGenerator: uidGenerator}
+}
+
+func (rr *UniqueValueRegistryRepository) Load(id string) (*UniqueValueRegistry, error) {
+	log.Debugf("Load id: %s", id)
+	r, err := NewUniqueValueRegistry(rr.es, rr.uidGenerator, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := batchLoader(rr.es, id, r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type UniqueValueRegistry struct {
+	id      string
+	version int64
+
+	values          map[string]util.ID
+	reserveRequests map[util.ID]struct{}
+	releaseRequests map[util.ID]struct{}
+
+	es           *eventstore.EventStore
+	uidGenerator common.UIDGenerator
+}
+
+func NewUniqueValueRegistry(es *eventstore.EventStore, uidGenerator common.UIDGenerator, id string) (*UniqueValueRegistry, error) {
+	return &UniqueValueRegistry{
+		id:              id,
+		values:          make(map[string]util.ID),
+		reserveRequests: make(map[util.ID]struct{}),
+		releaseRequests: make(map[util.ID]struct{}),
+
+		es:           es,
+		uidGenerator: uidGenerator,
+	}, nil
+}
+
+func (r *UniqueValueRegistry) Version() int64 {
+	return r.version
+}
+
+func (r *UniqueValueRegistry) ID() string {
+	return r.id
+}
+
+func (r *UniqueValueRegistry) AggregateType() eventstore.AggregateType {
+	return eventstore.UniqueValueRegistryAggregate
+}
+
+func (r *UniqueValueRegistry) HandleCommand(command *commands.Command) ([]eventstore.Event, error) {
+	var events []eventstore.Event
+	var err error
+	switch command.CommandType {
+	case commands.CommandTypeReserveValue:
+		events, err = r.HandleReserveValue(command)
+	case commands.CommandTypeReleaseValue:
+		events, err = r.HandleReleaseValue(command)
+
+	default:
+		err = fmt.Errorf("unhandled command: %#v", command)
+	}
+
+	return events, err
+}
+
+func (r *UniqueValueRegistry) HandleReserveValue(command *commands.Command) ([]eventstore.Event, error) {
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.ReserveValue)
+
+	if _, ok := r.reserveRequests[c.RequestID]; ok {
+		return nil, nil
+	}
+
+	if id, ok := r.values[c.Value]; ok {
+		if id == c.ID {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("value %s already reserved to id: %s", c.Value, id)
+	}
+
+	events = append(events, eventstore.NewEventUniqueRegistryValueReserved(r.id, c.Value, c.ID, c.RequestID))
+
+	return events, nil
+}
+
+func (r *UniqueValueRegistry) HandleReleaseValue(command *commands.Command) ([]eventstore.Event, error) {
+	log.Debugf("HandleReleaseValue")
+	events := []eventstore.Event{}
+
+	c := command.Data.(*commands.ReleaseValue)
+
+	if _, ok := r.releaseRequests[c.RequestID]; ok {
+		return nil, nil
+	}
+
+	if id, ok := r.values[c.Value]; ok {
+		log.Debugf("value: %s, id: %s", c.Value, id)
+		if id == c.ID {
+			events = append(events, eventstore.NewEventUniqueRegistryValueReleased(r.id, c.Value, c.ID, c.RequestID))
+		}
+	}
+	// ignore release for not reserved value or different id
+
+	return events, nil
+}
+
+func (r *UniqueValueRegistry) ApplyEvents(events []*eventstore.StoredEvent) error {
+	for _, e := range events {
+		if err := r.ApplyEvent(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *UniqueValueRegistry) ApplyEvent(event *eventstore.StoredEvent) error {
+	log.Debugf("event: %v", event)
+
+	data, err := event.UnmarshalData()
+	if err != nil {
+		return err
+	}
+
+	r.version = event.Version
+
+	switch event.EventType {
+	case eventstore.EventTypeUniqueRegistryValueReserved:
+		data := data.(*eventstore.EventUniqueRegistryValueReserved)
+		r.values[data.Value] = data.ID
+		r.reserveRequests[data.RequestID] = struct{}{}
+	case eventstore.EventTypeUniqueRegistryValueReleased:
+		data := data.(*eventstore.EventUniqueRegistryValueReleased)
+		delete(r.values, data.Value)
+		r.releaseRequests[data.RequestID] = struct{}{}
+	}
+
+	return nil
+}

--- a/change/change.go
+++ b/change/change.go
@@ -192,7 +192,6 @@ type CreateMemberChangeErrors struct {
 type UpdateMemberChange struct {
 	ID         util.ID
 	IsAdmin    bool
-	MatchUID   string
 	UserName   string
 	FullName   string
 	Email      string
@@ -207,7 +206,6 @@ type UpdateMemberResult struct {
 
 type UpdateMemberChangeErrors struct {
 	IsAdmin    error
-	MatchUID   error
 	UserName   error
 	FullName   error
 	Email      error

--- a/command/command.go
+++ b/command/command.go
@@ -1241,7 +1241,7 @@ func (s *CommandService) SetRoleAdditionalContent(ctx context.Context, roleID ut
 
 	command := commands.NewCommand(commands.CommandTypeSetRoleAdditionalContent, correlationID, causationID, callingMember.ID, commands.SetRoleAdditionalContent{RoleID: roleID, Content: content})
 
-	events = append(events, eventstore.NewEventRoleAdditionalContentSet(roleID, roleAdditionalContent))
+	events = append(events, eventstore.NewEventRoleAdditionalContentSet(roleID, roleAdditionalContent.Content))
 
 	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
 	if err != nil {
@@ -1430,7 +1430,7 @@ func (s *CommandService) createMember(ctx context.Context, c *change.CreateMembe
 		}
 	}
 
-	command := commands.NewCommand(commands.CommandTypeCreateMember, correlationID, causationID, callingMemberID, commands.NewCommandCreateMember(c, passwordHash))
+	command := commands.NewCommand(commands.CommandTypeCreateMember, correlationID, causationID, callingMemberID, commands.NewCommandCreateMember(c, passwordHash, avatar))
 
 	events = append(events, eventstore.NewEventMemberCreated(member))
 
@@ -1602,7 +1602,7 @@ func (s *CommandService) UpdateMember(ctx context.Context, c *change.UpdateMembe
 	groupID := s.uidGenerator.UUID("")
 	events := []eventstore.Event{}
 
-	command := commands.NewCommand(commands.CommandTypeUpdateMember, correlationID, causationID, callingMember.ID, commands.NewCommandUpdateMember(c))
+	command := commands.NewCommand(commands.CommandTypeUpdateMember, correlationID, causationID, callingMember.ID, commands.NewCommandUpdateMember(c, avatar))
 
 	events = append(events, eventstore.NewEventMemberUpdated(member))
 
@@ -1841,7 +1841,8 @@ func (s *CommandService) CreateTension(ctx context.Context, c *change.CreateTens
 	groupID := s.uidGenerator.UUID("")
 	events := []eventstore.Event{}
 
-	command := commands.NewCommand(commands.CommandTypeCreateTension, correlationID, causationID, callingMember.ID, commands.NewCommandCreateTension(c))
+	command := commands.NewCommand(commands.CommandTypeCreateTension, correlationID, causationID, callingMember.ID, commands.NewCommandCreateTension(callingMember.ID, c))
+
 	events = append(events, eventstore.NewEventTensionCreated(tension, callingMember.ID, c.RoleID))
 
 	wevents, err := s.writeEvents(events, command, groupID, eventstore.TensionAggregate, tension.ID.String(), version)

--- a/command/command.go
+++ b/command/command.go
@@ -3,16 +3,17 @@ package command
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"image"
 	"regexp"
 	"time"
 
+	"github.com/sorintlab/sircles/aggregate"
 	"github.com/sorintlab/sircles/change"
 	"github.com/sorintlab/sircles/command/commands"
 	"github.com/sorintlab/sircles/common"
 	"github.com/sorintlab/sircles/db"
 	"github.com/sorintlab/sircles/eventstore"
+	ln "github.com/sorintlab/sircles/listennotify"
 	slog "github.com/sorintlab/sircles/log"
 	"github.com/sorintlab/sircles/models"
 	"github.com/sorintlab/sircles/readdb"
@@ -61,50 +62,30 @@ func isUserNameValidFormat(s string) bool {
 }
 
 type CommandService struct {
+	dataDir      string
 	uidGenerator common.UIDGenerator
-	tg           common.TimeGenerator
-	tx           *db.Tx
-	readDB       readdb.ReadDBService
+	db           *db.DB
 	es           *eventstore.EventStore
+	lnf          ln.ListenerFactory
 
 	hasMemberProvider bool
 }
 
-func NewCommandService(tx *db.Tx, readDB readdb.ReadDBService, uidGenerator common.UIDGenerator, tg common.TimeGenerator, hasMemberProvider bool) *CommandService {
-	if uidGenerator == nil {
-		uidGenerator = &common.DefaultUidGenerator{}
-	}
-
-	if tg == nil {
-		tg = common.DefaultTimeGenerator{}
-	}
-
-	es := eventstore.NewEventStore(tx)
-	es.SetTimeGenerator(tg)
-
+func NewCommandService(dataDir string, db *db.DB, es *eventstore.EventStore, uidGenerator common.UIDGenerator, lnf ln.ListenerFactory, hasMemberProvider bool) *CommandService {
 	s := &CommandService{
+		dataDir:           dataDir,
 		uidGenerator:      uidGenerator,
-		tg:                tg,
-		tx:                tx,
-		readDB:            readDB,
+		db:                db,
 		es:                es,
+		lnf:               lnf,
 		hasMemberProvider: hasMemberProvider,
+	}
+	if uidGenerator == nil {
+		s.uidGenerator = &common.DefaultUidGenerator{}
 	}
 
 	return s
 }
-
-func (s *CommandService) writeEvents(events []eventstore.Event, command *commands.Command, groupID util.ID, aggregateType eventstore.AggregateType, aggregateID string, version int64) ([]*eventstore.StoredEvent, error) {
-	eventsData, err := eventstore.GenEventData(events, &command.CorrelationID, &command.ID, &groupID, &command.IssuerID)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.es.WriteEvents(eventsData, aggregateType.String(), aggregateID, version)
-}
-
-// VERY BIG TODO(sgotti)!!!
-// Move the validation outside command handling
 
 func (s *CommandService) UpdateRootRole(ctx context.Context, c *change.UpdateRootRoleChange) (*change.UpdateRootRoleResult, util.ID, error) {
 	res := &change.UpdateRootRoleResult{}
@@ -186,10 +167,20 @@ func (s *CommandService) UpdateRootRole(ctx context.Context, c *change.UpdateRoo
 	var role *models.Role
 	var err error
 
-	curTl := s.readDB.CurTimeLine(ctx)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
 	curTlSeq := curTl.Number()
 
-	role, err = s.readDB.Role(ctx, curTlSeq, c.ID)
+	role, err = readDBService.Role(ctx, curTlSeq, c.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -199,7 +190,7 @@ func (s *CommandService) UpdateRootRole(ctx context.Context, c *change.UpdateRoo
 		return res, util.NilID, ErrValidation
 	}
 
-	rootRole, err := s.readDB.RootRole(ctx, curTlSeq)
+	rootRole, err := readDBService.RootRole(ctx, curTlSeq)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -209,11 +200,11 @@ func (s *CommandService) UpdateRootRole(ctx context.Context, c *change.UpdateRoo
 		return res, util.NilID, ErrValidation
 	}
 
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, role.ID)
+	cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, role.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -223,129 +214,18 @@ func (s *CommandService) UpdateRootRole(ctx context.Context, c *change.UpdateRoo
 		return res, util.NilID, ErrValidation
 	}
 
-	// TODO(sgotti) split validation from event creation, this will lead to some
-	// code duplication
-
-	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	command := commands.NewCommand(commands.CommandTypeUpdateRootRole, correlationID, causationID, callingMember.ID, &commands.UpdateRootRole{UpdateRootRoleChange: *c})
 
-	if c.NameChanged {
-		if role.RoleType.IsCoreRoleType() {
-			return nil, util.NilID, errors.Errorf("cannot change core role name")
-		}
-		role.Name = c.Name
-	}
-
-	if c.PurposeChanged {
-		role.Purpose = c.Purpose
-	}
-
-	events = append(events, eventstore.NewEventRoleUpdated(role))
-
-	domainsGroups, err := s.readDB.RoleDomains(ctx, curTlSeq, []util.ID{role.ID})
+	rtr := aggregate.NewRolesTreeRepository(s.dataDir, s.es, s.uidGenerator)
+	rt, err := rtr.Load(eventstore.RolesTreeAggregateID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	domains := domainsGroups[role.ID]
 
-	accountabilitiesGroups, err := s.readDB.RoleAccountabilities(ctx, curTlSeq, []util.ID{role.ID})
+	groupID, _, err := aggregate.ExecCommand(command, rt, s.es, s.uidGenerator)
 	if err != nil {
-		return nil, util.NilID, err
-	}
-	accountabilities := accountabilitiesGroups[role.ID]
-
-	for _, createDomainChange := range c.CreateDomainChanges {
-		domain := models.Domain{}
-		domain.Description = createDomainChange.Description
-		domain.ID = s.uidGenerator.UUID(domain.Description)
-
-		events = append(events, eventstore.NewEventRoleDomainCreated(role.ID, &domain))
-	}
-
-	for _, deleteDomainChange := range c.DeleteDomainChanges {
-		found := false
-		for _, d := range domains {
-			if deleteDomainChange.ID == d.ID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, util.NilID, errors.Errorf("cannot delete unexistent domain %s", deleteDomainChange.ID)
-		}
-		events = append(events, eventstore.NewEventRoleDomainDeleted(role.ID, deleteDomainChange.ID))
-	}
-
-	for _, updateDomainChange := range c.UpdateDomainChanges {
-		var domain *models.Domain
-		for _, d := range domains {
-			if updateDomainChange.ID == d.ID {
-				domain = d
-				break
-			}
-		}
-		if domain == nil {
-			return nil, util.NilID, errors.Errorf("cannot update unexistent domain %s", updateDomainChange.ID)
-		}
-		if updateDomainChange.DescriptionChanged {
-			domain.Description = updateDomainChange.Description
-		}
-		events = append(events, eventstore.NewEventRoleDomainUpdated(role.ID, domain))
-	}
-
-	for _, createAccountabilityChange := range c.CreateAccountabilityChanges {
-		accountability := models.Accountability{}
-		accountability.Description = createAccountabilityChange.Description
-		accountability.ID = s.uidGenerator.UUID(accountability.Description)
-
-		events = append(events, eventstore.NewEventRoleAccountabilityCreated(role.ID, &accountability))
-	}
-
-	for _, deleteAccountabilityChange := range c.DeleteAccountabilityChanges {
-		found := false
-		for _, d := range accountabilities {
-			if deleteAccountabilityChange.ID == d.ID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, util.NilID, errors.Errorf("cannot delete unexistent accountability %s", deleteAccountabilityChange.ID)
-		}
-		events = append(events, eventstore.NewEventRoleAccountabilityDeleted(role.ID, deleteAccountabilityChange.ID))
-	}
-
-	for _, updateAccountabilityChange := range c.UpdateAccountabilityChanges {
-		var accountability *models.Accountability
-		for _, d := range accountabilities {
-			if updateAccountabilityChange.ID == d.ID {
-				accountability = d
-				break
-			}
-		}
-		if accountability == nil {
-			return nil, util.NilID, errors.Errorf("cannot update unexistent accountability %s", updateAccountabilityChange.ID)
-		}
-		if updateAccountabilityChange.DescriptionChanged {
-			accountability.Description = updateAccountabilityChange.Description
-		}
-		events = append(events, eventstore.NewEventRoleAccountabilityUpdated(role.ID, accountability))
-	}
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
-	if err != nil {
-		return nil, util.NilID, err
-	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
 		return nil, util.NilID, err
 	}
 
@@ -404,11 +284,19 @@ func (s *CommandService) CircleCreateChildRole(ctx context.Context, roleID util.
 		return res, util.NilID, ErrValidation
 	}
 
-	curTl := s.readDB.CurTimeLine(ctx)
-	curTlSeq := curTl.Number()
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
 
-	// check that parent role exists
-	prole, err := s.readDB.Role(ctx, curTlSeq, roleID)
+	curTl := readDBService.CurTimeLine(ctx)
+	curTlSeq := curTl.Number()
+	prole, err := readDBService.Role(ctx, curTlSeq, roleID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -423,11 +311,11 @@ func (s *CommandService) CircleCreateChildRole(ctx context.Context, roleID util.
 		return res, util.NilID, ErrValidation
 	}
 
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, prole.ID)
+	cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, prole.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -437,99 +325,25 @@ func (s *CommandService) CircleCreateChildRole(ctx context.Context, roleID util.
 		return res, util.NilID, ErrValidation
 	}
 
-	pChildsGroups, err := s.readDB.ChildRoles(ctx, curTlSeq, []util.ID{prole.ID}, nil)
-	if err != nil {
-		return nil, util.NilID, err
-	}
-	pChilds := pChildsGroups[prole.ID]
-
-	// Check that the roles to move from parent are valid
-	for _, rfp := range c.RolesFromParent {
-		found := false
-		for _, pChild := range pChilds {
-			if pChild.ID == rfp {
-				if pChild.RoleType.IsCoreRoleType() {
-					return nil, util.NilID, errors.Errorf("role %s to move from parent is a core role type (not a normal role or a circle)", rfp)
-				}
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, util.NilID, errors.Errorf("role %s to move from parent is not a child of parent role %s", rfp, prole.ID)
-		}
-	}
-
-	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
+	newRoleID := s.uidGenerator.UUID(c.Name)
 
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
+	command := commands.NewCommand(commands.CommandTypeCircleCreateChildRole, correlationID, causationID, callingMember.ID, &commands.CircleCreateChildRole{RoleID: roleID, NewRoleID: newRoleID, CreateRoleChange: *c})
 
-	command := commands.NewCommand(commands.CommandTypeCircleCreateChildRole, correlationID, causationID, callingMember.ID, &commands.CircleCreateChildRole{RoleID: roleID, CreateRoleChange: *c})
-
-	role := &models.Role{
-		Name:     c.Name,
-		RoleType: c.RoleType,
-		Purpose:  c.Purpose,
-	}
-
-	role.ID = s.uidGenerator.UUID(role.Name)
-
-	events = append(events, eventstore.NewEventRoleCreated(role, &roleID))
-
-	for _, createDomainChange := range c.CreateDomainChanges {
-		domain := models.Domain{}
-		domain.Description = createDomainChange.Description
-
-		domain.ID = s.uidGenerator.UUID(domain.Description)
-
-		events = append(events, eventstore.NewEventRoleDomainCreated(role.ID, &domain))
-	}
-
-	for _, createAccountabilityChange := range c.CreateAccountabilityChanges {
-		accountability := models.Accountability{}
-		accountability.Description = createAccountabilityChange.Description
-
-		accountability.ID = s.uidGenerator.UUID(accountability.Description)
-
-		events = append(events, eventstore.NewEventRoleAccountabilityCreated(role.ID, &accountability))
-	}
-
-	// Add core roles to circle
-	if c.RoleType == models.RoleTypeCircle {
-		es, err := s.roleAddCoreRoles(role, false)
-		if err != nil {
-			return nil, util.NilID, err
-		}
-		events = append(events, es...)
-	}
-
-	for _, pChild := range pChilds {
-		fromParent := false
-		for _, rfp := range c.RolesFromParent {
-			if pChild.ID == rfp {
-				fromParent = true
-			}
-		}
-		if fromParent {
-			events = append(events, eventstore.NewEventRoleChangedParent(pChild.ID, &role.ID))
-		}
-	}
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
+	rtr := aggregate.NewRolesTreeRepository(s.dataDir, s.es, s.uidGenerator)
+	rt, err := rtr.Load(eventstore.RolesTreeAggregateID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
+
+	groupID, _, err := aggregate.ExecCommand(command, rt, s.es, s.uidGenerator)
+	if err != nil {
 		return nil, util.NilID, err
 	}
 
-	res.RoleID = &role.ID
+	res.RoleID = &newRoleID
+
 	return res, groupID, nil
 }
 
@@ -613,10 +427,20 @@ func (s *CommandService) CircleUpdateChildRole(ctx context.Context, roleID util.
 	var role *models.Role
 	var err error
 
-	curTl := s.readDB.CurTimeLine(ctx)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
 	curTlSeq := curTl.Number()
 
-	role, err = s.readDB.Role(ctx, curTlSeq, c.ID)
+	role, err = readDBService.Role(ctx, curTlSeq, c.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -627,7 +451,7 @@ func (s *CommandService) CircleUpdateChildRole(ctx context.Context, roleID util.
 	}
 
 	var prole *models.Role
-	proleGroups, err := s.readDB.RoleParent(ctx, curTlSeq, []util.ID{role.ID})
+	proleGroups, err := readDBService.RoleParent(ctx, curTlSeq, []util.ID{role.ID})
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -645,11 +469,11 @@ func (s *CommandService) CircleUpdateChildRole(ctx context.Context, roleID util.
 		return res, util.NilID, ErrValidation
 	}
 
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, roleID)
+	cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, roleID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -659,408 +483,40 @@ func (s *CommandService) CircleUpdateChildRole(ctx context.Context, roleID util.
 		return res, util.NilID, ErrValidation
 	}
 
-	// TODO(sgotti) split validation from event creation, this will lead to some
-	// code duplication
-
-	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	command := commands.NewCommand(commands.CommandTypeCircleUpdateChildRole, correlationID, causationID, callingMember.ID, &commands.CircleUpdateChildRole{RoleID: roleID, UpdateRoleChange: *c})
 
-	childsGroups, err := s.readDB.ChildRoles(ctx, curTlSeq, []util.ID{role.ID}, nil)
+	rtr := aggregate.NewRolesTreeRepository(s.dataDir, s.es, s.uidGenerator)
+	rt, err := rtr.Load(eventstore.RolesTreeAggregateID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	childs := childsGroups[role.ID]
 
-	pChildsGroups, err := s.readDB.ChildRoles(ctx, curTlSeq, []util.ID{prole.ID}, nil)
+	groupID, _, err := aggregate.ExecCommand(command, rt, s.es, s.uidGenerator)
 	if err != nil {
-		return nil, util.NilID, err
-	}
-	pChilds := pChildsGroups[prole.ID]
-
-	// Check that the roles to keep are valid
-	for _, rtp := range c.RolesToParent {
-		found := false
-		for _, child := range childs {
-			if child.ID == rtp {
-				if child.RoleType.IsCoreRoleType() {
-					return nil, util.NilID, errors.Errorf("role %s to move to parent is a core role type (not a normal role or a circle)", rtp)
-				}
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, util.NilID, errors.Errorf("role %s to move to parent is not a child of role %s", rtp, role.ID)
-		}
-	}
-
-	// Check that the roles to move from parent are valid
-	for _, rfp := range c.RolesFromParent {
-		found := false
-		for _, pChild := range pChilds {
-			if pChild.ID == rfp {
-				if pChild.RoleType.IsCoreRoleType() {
-					return nil, util.NilID, errors.Errorf("role %s to move from parent is a core role type (not a normal role or a circle)", rfp)
-				}
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, util.NilID, errors.Errorf("role %s to move from parent is not a child of parent role %s", rfp, prole.ID)
-		}
-	}
-
-	if c.NameChanged {
-		if role.RoleType.IsCoreRoleType() {
-			return nil, util.NilID, errors.Errorf("cannot change core role name")
-		}
-		role.Name = c.Name
-	}
-
-	if c.PurposeChanged {
-		role.Purpose = c.Purpose
-	}
-
-	if c.MakeCircle {
-		if role.RoleType != models.RoleTypeNormal {
-			return nil, util.NilID, errors.Errorf("role with id %s of type %s cannot be transformed in a circle", role.ID, role.RoleType)
-		}
-		role.RoleType = models.RoleTypeCircle
-
-		// remove members filling the role ince it will become a circle
-		roleMemberEdgesGroups, err := s.readDB.RoleMemberEdges(ctx, curTlSeq, []util.ID{role.ID}, nil)
-		if err != nil {
-			return nil, util.NilID, err
-		}
-		roleMemberEdges := roleMemberEdgesGroups[role.ID]
-
-		for _, roleMemberEdge := range roleMemberEdges {
-			events = append(events, eventstore.NewEventRoleMemberRemoved(role.ID, roleMemberEdge.Member.ID))
-		}
-	}
-
-	if c.MakeRole {
-		if role.RoleType != models.RoleTypeCircle {
-			return nil, util.NilID, errors.Errorf("role with id %s isn't a circle", role.ID)
-		}
-
-		role.RoleType = models.RoleTypeNormal
-
-		circleDirectMembersGroups, err := s.readDB.CircleDirectMembers(ctx, curTlSeq, []util.ID{role.ID})
-		if err != nil {
-			return nil, util.NilID, err
-		}
-		circleDirectMembers := circleDirectMembersGroups[role.ID]
-
-		// Remove circle direct members since they don't exist on a role
-		for _, circleDirectMember := range circleDirectMembers {
-			events = append(events, eventstore.NewEventCircleDirectMemberRemoved(role.ID, circleDirectMember.ID))
-		}
-
-		// Remove circle leadLink member
-		es, err := s.circleUnsetLeadLinkMember(ctx, curTl, role.ID)
-		if err != nil {
-			return nil, util.NilID, err
-		}
-		events = append(events, es...)
-
-		// Remove circle core roles members
-		for _, rt := range []models.RoleType{models.RoleTypeRepLink, models.RoleTypeFacilitator, models.RoleTypeSecretary} {
-			es, err := s.circleUnsetCoreRoleMember(ctx, curTl, rt, role.ID)
-			if err != nil {
-				return nil, util.NilID, err
-			}
-			events = append(events, es...)
-		}
-	}
-
-	for _, child := range childs {
-		toParent := false
-		for _, rtp := range c.RolesToParent {
-			if child.ID == rtp {
-				toParent = true
-			}
-		}
-		if toParent {
-			events = append(events, eventstore.NewEventRoleChangedParent(child.ID, &prole.ID))
-		} else {
-			if c.MakeRole {
-				// recursive delete for sub roles
-				es, err := s.deleteRole(ctx, curTl, child.ID, nil)
-				if err != nil {
-					return nil, util.NilID, err
-				}
-				events = append(events, es...)
-			}
-		}
-	}
-
-	events = append(events, eventstore.NewEventRoleUpdated(role))
-
-	if c.MakeCircle {
-		// Add core roles to circle
-		es, err := s.roleAddCoreRoles(role, false)
-		if err != nil {
-			return nil, util.NilID, err
-		}
-		events = append(events, es...)
-	}
-
-	for _, pChild := range pChilds {
-		fromParent := false
-		for _, rfp := range c.RolesFromParent {
-			if pChild.ID == rfp {
-				fromParent = true
-			}
-		}
-		if fromParent {
-			events = append(events, eventstore.NewEventRoleChangedParent(pChild.ID, &role.ID))
-		}
-	}
-
-	domainsGroups, err := s.readDB.RoleDomains(ctx, curTlSeq, []util.ID{role.ID})
-	if err != nil {
-		return nil, util.NilID, err
-	}
-	domains := domainsGroups[role.ID]
-
-	accountabilitiesGroups, err := s.readDB.RoleAccountabilities(ctx, curTlSeq, []util.ID{role.ID})
-	if err != nil {
-		return nil, util.NilID, err
-	}
-	accountabilities := accountabilitiesGroups[role.ID]
-
-	for _, createDomainChange := range c.CreateDomainChanges {
-		domain := models.Domain{}
-		domain.Description = createDomainChange.Description
-		domain.ID = s.uidGenerator.UUID(domain.Description)
-
-		events = append(events, eventstore.NewEventRoleDomainCreated(role.ID, &domain))
-	}
-
-	for _, deleteDomainChange := range c.DeleteDomainChanges {
-		found := false
-		for _, d := range domains {
-			if deleteDomainChange.ID == d.ID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, util.NilID, errors.Errorf("cannot delete unexistent domain %s", deleteDomainChange.ID)
-		}
-		events = append(events, eventstore.NewEventRoleDomainDeleted(role.ID, deleteDomainChange.ID))
-	}
-
-	for _, updateDomainChange := range c.UpdateDomainChanges {
-		var domain *models.Domain
-		for _, d := range domains {
-			if updateDomainChange.ID == d.ID {
-				domain = d
-				break
-			}
-		}
-		if domain == nil {
-			return nil, util.NilID, errors.Errorf("cannot update unexistent domain %s", updateDomainChange.ID)
-		}
-		if updateDomainChange.DescriptionChanged {
-			domain.Description = updateDomainChange.Description
-		}
-		events = append(events, eventstore.NewEventRoleDomainUpdated(role.ID, domain))
-	}
-
-	for _, createAccountabilityChange := range c.CreateAccountabilityChanges {
-		accountability := models.Accountability{}
-		accountability.Description = createAccountabilityChange.Description
-		accountability.ID = s.uidGenerator.UUID(accountability.Description)
-
-		events = append(events, eventstore.NewEventRoleAccountabilityCreated(role.ID, &accountability))
-	}
-
-	for _, deleteAccountabilityChange := range c.DeleteAccountabilityChanges {
-		found := false
-		for _, d := range accountabilities {
-			if deleteAccountabilityChange.ID == d.ID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, util.NilID, errors.Errorf("cannot delete unexistent accountability %s", deleteAccountabilityChange.ID)
-		}
-		events = append(events, eventstore.NewEventRoleAccountabilityDeleted(role.ID, deleteAccountabilityChange.ID))
-	}
-
-	for _, updateAccountabilityChange := range c.UpdateAccountabilityChanges {
-		var accountability *models.Accountability
-		for _, d := range accountabilities {
-			if updateAccountabilityChange.ID == d.ID {
-				accountability = d
-				break
-			}
-		}
-		if accountability == nil {
-			return nil, util.NilID, errors.Errorf("cannot update unexistent accountability %s", updateAccountabilityChange.ID)
-		}
-		if updateAccountabilityChange.DescriptionChanged {
-			accountability.Description = updateAccountabilityChange.Description
-		}
-		events = append(events, eventstore.NewEventRoleAccountabilityUpdated(role.ID, accountability))
-	}
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
-	if err != nil {
-		return nil, util.NilID, err
-	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
 		return nil, util.NilID, err
 	}
 
 	return res, groupID, nil
 }
 
-func (s *CommandService) deleteRole(ctx context.Context, curTl *util.TimeLine, roleID util.ID, skipchilds []util.ID) ([]eventstore.Event, error) {
-	events := []eventstore.Event{}
-
-	curTlSeq := curTl.Number()
-
-	role, err := s.readDB.Role(ctx, curTlSeq, roleID)
-	if err != nil {
-		return nil, err
-	}
-	if role == nil {
-		return nil, errors.Errorf("role with id %s doesn't exist", roleID)
-	}
-
-	proleGroups, err := s.readDB.RoleParent(ctx, curTlSeq, []util.ID{roleID})
-	if err != nil {
-		return nil, err
-	}
-	prole := proleGroups[roleID]
-	if prole == nil {
-		return nil, errors.Errorf("role with id %s doesn't have a parent", roleID)
-	}
-
-	childsGroups, err := s.readDB.ChildRoles(ctx, curTlSeq, []util.ID{roleID}, nil)
-	if err != nil {
-		return nil, err
-	}
-	childs := childsGroups[roleID]
-
-	domainsGroups, err := s.readDB.RoleDomains(ctx, curTlSeq, []util.ID{roleID})
-	if err != nil {
-		return nil, err
-	}
-	domains := domainsGroups[roleID]
-
-	accountabilitiesGroups, err := s.readDB.RoleAccountabilities(ctx, curTlSeq, []util.ID{roleID})
-	if err != nil {
-		return nil, err
-	}
-	accountabilities := accountabilitiesGroups[roleID]
-
-	if role.RoleType == models.RoleTypeNormal {
-		// Remove role members (on normal role)
-		roleMemberEdgesGroups, err := s.readDB.RoleMemberEdges(ctx, curTlSeq, []util.ID{roleID}, nil)
-		if err != nil {
-			return nil, err
-		}
-		roleMemberEdges := roleMemberEdgesGroups[roleID]
-		for _, roleMemberEdge := range roleMemberEdges {
-			events = append(events, eventstore.NewEventRoleMemberRemoved(roleID, roleMemberEdge.Member.ID))
-		}
-	}
-
-	if role.RoleType == models.RoleTypeCircle {
-		// Remove circle direct members (on circle)
-		circleDirectMembersGroups, err := s.readDB.CircleDirectMembers(ctx, curTlSeq, []util.ID{roleID})
-		if err != nil {
-			return nil, err
-		}
-		circleDirectMembers := circleDirectMembersGroups[roleID]
-		for _, circleDirectMember := range circleDirectMembers {
-			events = append(events, eventstore.NewEventCircleDirectMemberRemoved(roleID, circleDirectMember.ID))
-		}
-
-		// Remove circle leadLink member
-		es, err := s.circleUnsetLeadLinkMember(ctx, curTl, roleID)
-		if err != nil {
-			return nil, err
-		}
-		events = append(events, es...)
-
-		// Remove circle core roles members
-		for _, rt := range []models.RoleType{models.RoleTypeRepLink, models.RoleTypeFacilitator, models.RoleTypeSecretary} {
-			es, err := s.circleUnsetCoreRoleMember(ctx, curTl, rt, roleID)
-			if err != nil {
-				return nil, err
-			}
-			events = append(events, es...)
-		}
-
-		// recursive delete for sub roles
-		for _, child := range childs {
-			// ignore childs moved to parent
-			skip := false
-			for _, cid := range skipchilds {
-				if child.ID == cid {
-					skip = true
-				}
-			}
-			if skip {
-				continue
-			}
-			es, err := s.deleteRole(ctx, curTl, child.ID, nil)
-			if err != nil {
-				return nil, err
-			}
-			events = append(events, es...)
-		}
-	}
-
-	// Remove domains from role
-	for _, domain := range domains {
-		events = append(events, eventstore.NewEventRoleDomainDeleted(roleID, domain.ID))
-	}
-
-	// Remove accountabilities from role
-	for _, accountability := range accountabilities {
-		events = append(events, eventstore.NewEventRoleAccountabilityDeleted(roleID, accountability.ID))
-	}
-
-	// First register roleDeleteEvent since its ID will be the causation ID of subsequent events
-	roleDeletedEvent := eventstore.NewEventRoleDeleted(roleID)
-	events = append(events, roleDeletedEvent)
-
-	// TODO(sgotti) in future move this to a reaction from the tensions aggregate event listener (when/if implemented) on the roleDelete event
-	roleTensionsGroups, err := s.readDB.RoleTensions(ctx, curTlSeq, []util.ID{roleID})
-	if err != nil {
-		return nil, err
-	}
-	roleTensions := roleTensionsGroups[roleID]
-	for _, roleTension := range roleTensions {
-		events = append(events, eventstore.NewEventTensionRoleChanged(roleTension.ID, &roleID, nil))
-	}
-
-	return events, nil
-}
-
 func (s *CommandService) CircleDeleteChildRole(ctx context.Context, roleID util.ID, c *change.DeleteRoleChange) (*change.DeleteRoleResult, util.ID, error) {
 	res := &change.DeleteRoleResult{}
-	curTl := s.readDB.CurTimeLine(ctx)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
 	curTlSeq := curTl.Number()
 
-	role, err := s.readDB.Role(ctx, curTlSeq, c.ID)
+	role, err := readDBService.Role(ctx, curTlSeq, c.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1078,7 +534,7 @@ func (s *CommandService) CircleDeleteChildRole(ctx context.Context, roleID util.
 		}
 	}
 
-	proleGroups, err := s.readDB.RoleParent(ctx, curTlSeq, []util.ID{role.ID})
+	proleGroups, err := readDBService.RoleParent(ctx, curTlSeq, []util.ID{role.ID})
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1095,7 +551,7 @@ func (s *CommandService) CircleDeleteChildRole(ctx context.Context, roleID util.
 		return res, util.NilID, ErrValidation
 	}
 
-	childsGroups, err := s.readDB.ChildRoles(ctx, curTlSeq, []util.ID{role.ID}, nil)
+	childsGroups, err := readDBService.ChildRoles(ctx, curTlSeq, []util.ID{role.ID}, nil)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1126,11 +582,11 @@ func (s *CommandService) CircleDeleteChildRole(ctx context.Context, roleID util.
 		return res, util.NilID, ErrValidation
 	}
 
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, prole.ID)
+	cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, prole.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1140,43 +596,18 @@ func (s *CommandService) CircleDeleteChildRole(ctx context.Context, roleID util.
 		return res, util.NilID, ErrValidation
 	}
 
-	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	command := commands.NewCommand(commands.CommandTypeCircleDeleteChildRole, correlationID, causationID, callingMember.ID, &commands.CircleDeleteChildRole{RoleID: roleID, DeleteRoleChange: *c})
 
-	skipchilds := []util.ID{}
-	for _, child := range childs {
-		toParent := false
-		for _, rtp := range c.RolesToParent {
-			if child.ID == rtp {
-				toParent = true
-				skipchilds = append(skipchilds, child.ID)
-			}
-		}
-		if toParent {
-			events = append(events, eventstore.NewEventRoleChangedParent(child.ID, &prole.ID))
-		}
-	}
-
-	es, err := s.deleteRole(ctx, curTl, role.ID, skipchilds)
+	rtr := aggregate.NewRolesTreeRepository(s.dataDir, s.es, s.uidGenerator)
+	rt, err := rtr.Load(eventstore.RolesTreeAggregateID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	events = append(events, es...)
 
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
+	groupID, _, err := aggregate.ExecCommand(command, rt, s.es, s.uidGenerator)
 	if err != nil {
-		return nil, util.NilID, err
-	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
 		return nil, util.NilID, err
 	}
 
@@ -1191,15 +622,25 @@ func (s *CommandService) SetRoleAdditionalContent(ctx context.Context, roleID ut
 		return res, util.NilID, ErrValidation
 	}
 
-	curTl := s.readDB.CurTimeLine(ctx)
-	curTlSeq := curTl.Number()
-
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
 	if err != nil {
 		return nil, util.NilID, err
 	}
 
-	role, err := s.readDB.Role(ctx, curTlSeq, roleID)
+	curTl := readDBService.CurTimeLine(ctx)
+	curTlSeq := curTl.Number()
+
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	role, err := readDBService.Role(ctx, curTlSeq, roleID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1208,13 +649,8 @@ func (s *CommandService) SetRoleAdditionalContent(ctx context.Context, roleID ut
 		res.GenericError = errors.Errorf("role with id %s doesn't exist", roleID)
 		return res, util.NilID, ErrValidation
 	}
-	if role.RoleType != models.RoleTypeCircle {
-		res.HasErrors = true
-		res.GenericError = errors.Errorf("role with id %s is not a circle", roleID)
-		return res, util.NilID, ErrValidation
-	}
 
-	cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, roleID)
+	cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, roleID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1229,25 +665,18 @@ func (s *CommandService) SetRoleAdditionalContent(ctx context.Context, roleID ut
 	}
 	roleAdditionalContent.ID = roleID
 
-	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
+	command := commands.NewCommand(commands.CommandTypeSetRoleAdditionalContent, correlationID, causationID, callingMember.ID, &commands.SetRoleAdditionalContent{RoleID: roleID, Content: content})
 
-	command := commands.NewCommand(commands.CommandTypeSetRoleAdditionalContent, correlationID, causationID, callingMember.ID, commands.SetRoleAdditionalContent{RoleID: roleID, Content: content})
-
-	events = append(events, eventstore.NewEventRoleAdditionalContentSet(roleID, roleAdditionalContent.Content))
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
+	rtr := aggregate.NewRolesTreeRepository(s.dataDir, s.es, s.uidGenerator)
+	rt, err := rtr.Load(eventstore.RolesTreeAggregateID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
+
+	groupID, _, err := aggregate.ExecCommand(command, rt, s.es, s.uidGenerator)
+	if err != nil {
 		return nil, util.NilID, err
 	}
 
@@ -1352,12 +781,22 @@ func (s *CommandService) createMember(ctx context.Context, c *change.CreateMembe
 		res.CreateMemberChangeErrors.AvatarData = errors.Errorf("wrong photo size: %dx%d", ic.Width, ic.Height)
 	}
 
-	curTl := s.readDB.CurTimeLine(ctx)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
 	curTlSeq := curTl.Number()
 
 	callingMemberID := util.NilID
 	if checkAuth {
-		callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+		callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 		if err != nil {
 			return nil, util.NilID, err
 		}
@@ -1373,7 +812,7 @@ func (s *CommandService) createMember(ctx context.Context, c *change.CreateMembe
 	// check that the username and email aren't already in use
 	// TODO(sgotti) get members by username or email directly from the db
 	// instead of scanning all the members
-	members, err := s.readDB.MembersByIDs(ctx, curTlSeq, nil)
+	members, err := readDBService.MembersByIDs(ctx, curTlSeq, nil)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1390,7 +829,7 @@ func (s *CommandService) createMember(ctx context.Context, c *change.CreateMembe
 
 	if c.MatchUID != "" {
 		// check that the member matchUID isn't already in use
-		member, err := s.readDB.MemberByMatchUID(ctx, c.MatchUID)
+		member, err := readDBService.MemberByMatchUID(ctx, c.MatchUID)
 		if err != nil {
 			return nil, util.NilID, err
 		}
@@ -1412,16 +851,6 @@ func (s *CommandService) createMember(ctx context.Context, c *change.CreateMembe
 	}
 	member.ID = s.uidGenerator.UUID(member.UserName)
 
-	version, err := s.es.StreamVersion(member.ID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
-	correlationID := s.uidGenerator.UUID("")
-	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	var passwordHash string
 	if c.Password != "" {
 		passwordHash, err = util.PasswordHash(c.Password)
@@ -1430,30 +859,32 @@ func (s *CommandService) createMember(ctx context.Context, c *change.CreateMembe
 		}
 	}
 
-	command := commands.NewCommand(commands.CommandTypeCreateMember, correlationID, causationID, callingMemberID, commands.NewCommandCreateMember(c, util.NilID, passwordHash, avatar))
+	correlationID := s.uidGenerator.UUID("")
+	causationID := s.uidGenerator.UUID("")
+	command := commands.NewCommand(commands.CommandTypeRequestCreateMember, correlationID, causationID, callingMemberID, commands.NewCommandRequestCreateMember(c, member.ID, passwordHash, avatar))
 
-	events = append(events, eventstore.NewEventMemberCreated(member, util.NilID))
-
-	events = append(events, eventstore.NewEventMemberAvatarSet(member.ID, avatar))
-
-	if c.Password != "" {
-		events = append(events, eventstore.NewEventMemberPasswordSet(member.ID, passwordHash))
-	}
-
-	if c.MatchUID != "" {
-		events = append(events, eventstore.NewEventMemberMatchUIDSet(member.ID, util.NilID, c.MatchUID, ""))
-	}
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.MemberAggregate, member.ID.String(), version)
+	memberChangeID := s.uidGenerator.UUID("")
+	mcr := aggregate.NewMemberChangeRepository(s.es, s.uidGenerator)
+	mc, err := mcr.Load(memberChangeID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
+
+	groupID, _, err := aggregate.ExecCommand(command, mc, s.es, s.uidGenerator)
+	if err != nil {
 		return nil, util.NilID, err
 	}
 
+	log.Debugf("waiting for request completed event for memberChangeID: %s", memberChangeID)
+	groupID, err = s.waitMemberChangeRequest(ctx, memberChangeID)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	log.Debugf("received request completed event for memberChangeID: %s, groupID: %s", memberChangeID, groupID)
+
 	res.MemberID = &member.ID
-	return res, groupID, nil
+
+	return res, groupID, err
 }
 
 func (s *CommandService) UpdateMember(ctx context.Context, c *change.UpdateMemberChange) (*change.UpdateMemberResult, util.ID, error) {
@@ -1500,10 +931,20 @@ func (s *CommandService) UpdateMember(ctx context.Context, c *change.UpdateMembe
 		res.UpdateMemberChangeErrors.Email = errors.Errorf("email address too long")
 	}
 
-	curTl := s.readDB.CurTimeLine(ctx)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
 	curTlSeq := curTl.Number()
 
-	member, err := s.readDB.Member(ctx, curTlSeq, c.ID)
+	member, err := readDBService.Member(ctx, curTlSeq, c.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1522,7 +963,7 @@ func (s *CommandService) UpdateMember(ctx context.Context, c *change.UpdateMembe
 	}
 
 	// Only an admin or the same member can update a member
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1535,7 +976,7 @@ func (s *CommandService) UpdateMember(ctx context.Context, c *change.UpdateMembe
 	// check that the username and email aren't already in use
 	// TODO(sgotti) get members by username or email directly from the db
 	// instead of scanning all the members
-	members, err := s.readDB.MembersByIDs(ctx, curTlSeq, nil)
+	members, err := readDBService.MembersByIDs(ctx, curTlSeq, nil)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1595,36 +1036,33 @@ func (s *CommandService) UpdateMember(ctx context.Context, c *change.UpdateMembe
 	member.FullName = c.FullName
 	member.Email = c.Email
 
-	version, err := s.es.StreamVersion(member.ID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
+	command := commands.NewCommand(commands.CommandTypeRequestUpdateMember, correlationID, causationID, callingMember.ID, commands.NewCommandRequestUpdateMember(c, member.ID, avatar, prevUserName, prevEmail))
 
-	command := commands.NewCommand(commands.CommandTypeUpdateMember, correlationID, causationID, callingMember.ID, commands.NewCommandUpdateMember(c, util.NilID, avatar, prevUserName, prevEmail))
-
-	events = append(events, eventstore.NewEventMemberUpdated(member, util.NilID, prevUserName, prevEmail))
-
-	if avatar != nil {
-		events = append(events, eventstore.NewEventMemberAvatarSet(member.ID, avatar))
-	}
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.MemberAggregate, member.ID.String(), version)
+	memberChangeID := s.uidGenerator.UUID("")
+	mcr := aggregate.NewMemberChangeRepository(s.es, s.uidGenerator)
+	mc, err := mcr.Load(memberChangeID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
+
+	groupID, _, err := aggregate.ExecCommand(command, mc, s.es, s.uidGenerator)
+	if err != nil {
 		return nil, util.NilID, err
 	}
+
+	log.Debugf("waiting for request completed event for memberChangeID: %s", memberChangeID)
+	groupID, err = s.waitMemberChangeRequest(ctx, memberChangeID)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	log.Debugf("received request completed event for memberChangeID: %s, groupID: %s", memberChangeID, groupID)
 
 	return res, groupID, nil
 }
 
-func (s *CommandService) SetMemberPassword(ctx context.Context, memberID util.ID, curPassword, newPassword string) (*change.GenericResult, error) {
+func (s *CommandService) SetMemberPassword(ctx context.Context, memberID util.ID, curPassword, newPassword string) (*change.GenericResult, util.ID, error) {
 	res := &change.GenericResult{}
 	if newPassword == "" {
 		res.HasErrors = true
@@ -1639,129 +1077,143 @@ func (s *CommandService) SetMemberPassword(ctx context.Context, memberID util.ID
 		}
 	}
 
-	curTl := s.readDB.CurTimeLine(ctx)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
 
 	curTlSeq := curTl.Number()
 
 	// Only the same user or an admin can set member password
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 	if err != nil {
-		return nil, err
+		return nil, util.NilID, err
 	}
 	if !callingMember.IsAdmin && callingMember.ID != memberID {
 		res.HasErrors = true
 		res.GenericError = errors.Errorf("member not authorized")
-		return res, ErrValidation
+		return res, util.NilID, ErrValidation
 	}
 
 	// Also admin needs to provide his current password
 	if !callingMember.IsAdmin || callingMember.ID == memberID {
-		if _, err = s.readDB.AuthenticateUIDPassword(ctx, memberID, curPassword); err != nil {
+		if _, err = readDBService.AuthenticateUIDPassword(ctx, memberID, curPassword); err != nil {
 			res.HasErrors = true
 			res.GenericError = errors.Errorf("member not authorized")
-			return res, ErrValidation
+			return res, util.NilID, ErrValidation
 		}
 	}
 
-	version, err := s.es.StreamVersion(memberID.String())
+	passwordHash, err := util.PasswordHash(newPassword)
 	if err != nil {
-		return nil, err
+		return nil, util.NilID, err
 	}
 
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
+	command := commands.NewCommand(commands.CommandTypeSetMemberPassword, correlationID, causationID, callingMember.ID, &commands.SetMemberPassword{PasswordHash: passwordHash})
 
-	passwordHash, err := util.PasswordHash(newPassword)
+	mr := aggregate.NewMemberRepository(s.es, s.uidGenerator)
+	m, err := mr.Load(memberID)
 	if err != nil {
-		return nil, err
+		return nil, util.NilID, err
 	}
 
-	command := commands.NewCommand(commands.CommandTypeSetMemberPassword, correlationID, causationID, callingMember.ID, commands.SetMemberPassword{PasswordHash: passwordHash})
-
-	events = append(events, eventstore.NewEventMemberPasswordSet(memberID, passwordHash))
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.MemberAggregate, memberID.String(), version)
+	groupID, _, err := aggregate.ExecCommand(command, m, s.es, s.uidGenerator)
 	if err != nil {
-		return nil, err
-	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
-		return nil, err
+		return nil, util.NilID, err
 	}
 
-	return res, nil
+	return res, groupID, nil
 }
 
-func (s *CommandService) SetMemberMatchUID(ctx context.Context, memberID util.ID, matchUID string) (*change.GenericResult, error) {
+func (s *CommandService) SetMemberMatchUID(ctx context.Context, memberID util.ID, matchUID string) (*change.GenericResult, util.ID, error) {
 	return s.setMemberMatchUID(ctx, memberID, matchUID, false)
 }
 
-func (s *CommandService) SetMemberMatchUIDInternal(ctx context.Context, memberID util.ID, matchUID string) (*change.GenericResult, error) {
+func (s *CommandService) SetMemberMatchUIDInternal(ctx context.Context, memberID util.ID, matchUID string) (*change.GenericResult, util.ID, error) {
 	return s.setMemberMatchUID(ctx, memberID, matchUID, false)
 }
 
-func (s *CommandService) setMemberMatchUID(ctx context.Context, memberID util.ID, matchUID string, internal bool) (*change.GenericResult, error) {
+func (s *CommandService) setMemberMatchUID(ctx context.Context, memberID util.ID, matchUID string, internal bool) (*change.GenericResult, util.ID, error) {
 	res := &change.GenericResult{}
 	if len([]rune(matchUID)) > MaxMemberMatchUID {
 		res.HasErrors = true
 		res.GenericError = errors.Errorf("matchUID too long")
 	}
 
-	curTl := s.readDB.CurTimeLine(ctx)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
 
 	curTlSeq := curTl.Number()
 
 	callingMemberID := util.NilID
 	if !internal {
-		callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+		callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 		if err != nil {
-			return nil, err
+			return nil, util.NilID, err
 		}
 
 		// only admin can set a member matchUID
 		if !callingMember.IsAdmin {
 			res.HasErrors = true
 			res.GenericError = errors.Errorf("member not authorized")
-			return res, ErrValidation
+			return res, util.NilID, ErrValidation
 		}
 		callingMemberID = callingMember.ID
 	}
 
 	// check that the member matchUID isn't already in use
-	member, err := s.readDB.MemberByMatchUID(ctx, matchUID)
+	member, err := readDBService.MemberByMatchUID(ctx, matchUID)
 	if err != nil {
-		return nil, err
+		return nil, util.NilID, err
 	}
 	if member != nil {
 		res.HasErrors = true
 		res.GenericError = errors.Errorf("matchUID already in use")
-	}
-
-	version, err := s.es.StreamVersion(memberID.String())
-	if err != nil {
-		return nil, err
+		return res, util.NilID, ErrValidation
 	}
 
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
+	command := commands.NewCommand(commands.CommandTypeRequestSetMemberMatchUID, correlationID, causationID, callingMemberID, &commands.RequestSetMemberMatchUID{member.ID, matchUID})
 
-	// NOTE(sgotti) Changing a password doesn't require a new timeline since there's no history of previous password, the command will have an empty timeline
-	command := commands.NewCommand(commands.CommandTypeSetMemberMatchUID, correlationID, causationID, callingMemberID, commands.SetMemberMatchUID{MatchUID: matchUID})
-
-	events = append(events, eventstore.NewEventMemberMatchUIDSet(memberID, util.NilID, matchUID, ""))
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.MemberAggregate, memberID.String(), version)
+	memberChangeID := s.uidGenerator.UUID("")
+	mcr := aggregate.NewMemberChangeRepository(s.es, s.uidGenerator)
+	mc, err := mcr.Load(memberChangeID)
 	if err != nil {
-		return nil, err
-	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
-		return nil, err
+		return nil, util.NilID, err
 	}
 
-	return res, nil
+	groupID, _, err := aggregate.ExecCommand(command, mc, s.es, s.uidGenerator)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	log.Debugf("waiting for request completed event for memberChangeID: %s", memberChangeID)
+	groupID, err = s.waitMemberChangeRequest(ctx, memberChangeID)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	log.Debugf("received request completed event for memberChangeID: %s, groupID: %s", memberChangeID, groupID)
+
+	return res, groupID, nil
 }
 
 func (s *CommandService) CreateTension(ctx context.Context, c *change.CreateTensionChange) (*change.CreateTensionResult, util.ID, error) {
@@ -1783,16 +1235,26 @@ func (s *CommandService) CreateTension(ctx context.Context, c *change.CreateTens
 		return res, util.NilID, ErrValidation
 	}
 
-	curTl := s.readDB.CurTimeLine(ctx)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
 	curTlSeq := curTl.Number()
 
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 	if err != nil {
 		return nil, util.NilID, err
 	}
 
 	if c.RoleID != nil {
-		role, err := s.readDB.Role(ctx, curTlSeq, *c.RoleID)
+		role, err := readDBService.Role(ctx, curTlSeq, *c.RoleID)
 		if err != nil {
 			return nil, util.NilID, err
 		}
@@ -1807,8 +1269,7 @@ func (s *CommandService) CreateTension(ctx context.Context, c *change.CreateTens
 			return res, util.NilID, ErrValidation
 		}
 		// Check that the user is a member of the role
-		// TODO(sgotti) if the user will be removed we currently leave the tensions as is
-		circleMemberEdgesGroups, err := s.readDB.CircleMemberEdges(ctx, curTlSeq, []util.ID{role.ID})
+		circleMemberEdgesGroups, err := readDBService.CircleMemberEdges(ctx, curTlSeq, []util.ID{role.ID})
 		if err != nil {
 			return nil, util.NilID, err
 		}
@@ -1828,35 +1289,25 @@ func (s *CommandService) CreateTension(ctx context.Context, c *change.CreateTens
 
 	}
 
-	tension := &models.Tension{
-		Title:       c.Title,
-		Description: c.Description,
-	}
-	tension.ID = s.uidGenerator.UUID(tension.Title)
-
-	version, err := s.es.StreamVersion(tension.ID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
+	tensionID := s.uidGenerator.UUID(c.Title)
 
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	command := commands.NewCommand(commands.CommandTypeCreateTension, correlationID, causationID, callingMember.ID, commands.NewCommandCreateTension(callingMember.ID, c))
 
-	events = append(events, eventstore.NewEventTensionCreated(tension, callingMember.ID, c.RoleID))
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.TensionAggregate, tension.ID.String(), version)
+	tr := aggregate.NewTensionRepository(s.es, s.uidGenerator)
+	t, err := tr.Load(tensionID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
+
+	groupID, _, err := aggregate.ExecCommand(command, t, s.es, s.uidGenerator)
+	if err != nil {
 		return nil, util.NilID, err
 	}
 
-	res.TensionID = &tension.ID
+	res.TensionID = &tensionID
+
 	return res, groupID, nil
 }
 
@@ -1879,15 +1330,25 @@ func (s *CommandService) UpdateTension(ctx context.Context, c *change.UpdateTens
 		return res, util.NilID, ErrValidation
 	}
 
-	curTl := s.readDB.CurTimeLine(ctx)
-	curTlSeq := curTl.Number()
-
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
 	if err != nil {
 		return nil, util.NilID, err
 	}
 
-	tension, err := s.readDB.Tension(ctx, curTlSeq, c.ID)
+	curTl := readDBService.CurTimeLine(ctx)
+	curTlSeq := curTl.Number()
+
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	tension, err := readDBService.Tension(ctx, curTlSeq, c.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1904,17 +1365,11 @@ func (s *CommandService) UpdateTension(ctx context.Context, c *change.UpdateTens
 		return res, util.NilID, ErrValidation
 	}
 
-	tensionMemberGroups, err := s.readDB.TensionMember(ctx, curTlSeq, []util.ID{tension.ID})
+	tensionMemberGroups, err := readDBService.TensionMember(ctx, curTlSeq, []util.ID{tension.ID})
 	if err != nil {
 		return nil, util.NilID, err
 	}
 	tensionMember := tensionMemberGroups[tension.ID]
-
-	tensionRoleGroups, err := s.readDB.TensionRole(ctx, curTlSeq, []util.ID{tension.ID})
-	if err != nil {
-		return nil, util.NilID, err
-	}
-	tensionRole := tensionRoleGroups[tension.ID]
 
 	// Assume that a tension always have a member, or something is wrong
 	if !callingMember.IsAdmin && callingMember.ID != tensionMember.ID {
@@ -1924,7 +1379,7 @@ func (s *CommandService) UpdateTension(ctx context.Context, c *change.UpdateTens
 	}
 
 	if c.RoleID != nil {
-		role, err := s.readDB.Role(ctx, curTlSeq, *c.RoleID)
+		role, err := readDBService.Role(ctx, curTlSeq, *c.RoleID)
 		if err != nil {
 			return nil, util.NilID, err
 		}
@@ -1939,8 +1394,7 @@ func (s *CommandService) UpdateTension(ctx context.Context, c *change.UpdateTens
 			return res, util.NilID, ErrValidation
 		}
 		// Check that the user is a member of the role
-		// TODO(sgotti) if the user will be removed we currently leave the tensions as is
-		circleMemberEdgesGroups, err := s.readDB.CircleMemberEdges(ctx, curTlSeq, []util.ID{role.ID})
+		circleMemberEdgesGroups, err := readDBService.CircleMemberEdges(ctx, curTlSeq, []util.ID{role.ID})
 		if err != nil {
 			return nil, util.NilID, err
 		}
@@ -1959,46 +1413,18 @@ func (s *CommandService) UpdateTension(ctx context.Context, c *change.UpdateTens
 		}
 	}
 
-	tension.Title = c.Title
-	tension.Description = c.Description
-
-	roleChanged := false
-	var prevRoleID *util.ID
-	if tensionRole != nil {
-		prevRoleID = &tensionRole.ID
-	}
-	if tensionRole != nil && c.RoleID != nil {
-		if tensionRole.ID != *c.RoleID {
-			roleChanged = true
-		}
-	}
-	if tensionRole == nil && c.RoleID != nil || tensionRole != nil && c.RoleID == nil {
-		roleChanged = true
-	}
-
-	version, err := s.es.StreamVersion(tension.ID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	command := commands.NewCommand(commands.CommandTypeUpdateTension, correlationID, causationID, callingMember.ID, commands.NewCommandUpdateTension(c))
 
-	if roleChanged {
-		events = append(events, eventstore.NewEventTensionRoleChanged(tension.ID, prevRoleID, c.RoleID))
-	}
-
-	events = append(events, eventstore.NewEventTensionUpdated(tension))
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.TensionAggregate, tension.ID.String(), version)
+	tr := aggregate.NewTensionRepository(s.es, s.uidGenerator)
+	t, err := tr.Load(c.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
+
+	groupID, _, err := aggregate.ExecCommand(command, t, s.es, s.uidGenerator)
+	if err != nil {
 		return nil, util.NilID, err
 	}
 
@@ -2014,15 +1440,25 @@ func (s *CommandService) CloseTension(ctx context.Context, c *change.CloseTensio
 		return res, util.NilID, ErrValidation
 	}
 
-	curTl := s.readDB.CurTimeLine(ctx)
-	curTlSeq := curTl.Number()
-
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
 	if err != nil {
 		return nil, util.NilID, err
 	}
 
-	tension, err := s.readDB.Tension(ctx, curTlSeq, c.ID)
+	curTl := readDBService.CurTimeLine(ctx)
+	curTlSeq := curTl.Number()
+
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	tension, err := readDBService.Tension(ctx, curTlSeq, c.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2039,7 +1475,7 @@ func (s *CommandService) CloseTension(ctx context.Context, c *change.CloseTensio
 		return res, util.NilID, ErrValidation
 	}
 
-	tensionMemberGroups, err := s.readDB.TensionMember(ctx, curTlSeq, []util.ID{tension.ID})
+	tensionMemberGroups, err := readDBService.TensionMember(ctx, curTlSeq, []util.ID{tension.ID})
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2052,25 +1488,18 @@ func (s *CommandService) CloseTension(ctx context.Context, c *change.CloseTensio
 		return res, util.NilID, ErrValidation
 	}
 
-	version, err := s.es.StreamVersion(tension.ID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	command := commands.NewCommand(commands.CommandTypeCloseTension, correlationID, causationID, callingMember.ID, commands.NewCommandCloseTension(c))
 
-	events = append(events, eventstore.NewEventTensionClosed(tension.ID, c.Reason))
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.TensionAggregate, tension.ID.String(), version)
+	tr := aggregate.NewTensionRepository(s.es, s.uidGenerator)
+	t, err := tr.Load(c.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
+
+	groupID, _, err := aggregate.ExecCommand(command, t, s.es, s.uidGenerator)
+	if err != nil {
 		return nil, util.NilID, err
 	}
 
@@ -2081,14 +1510,24 @@ func (s *CommandService) CloseTension(ctx context.Context, c *change.CloseTensio
 func (s *CommandService) CircleAddDirectMember(ctx context.Context, roleID util.ID, memberID util.ID) (*change.GenericResult, util.ID, error) {
 	res := &change.GenericResult{}
 
-	curTl := s.readDB.CurTimeLine(ctx)
-	curTlSeq := curTl.Number()
-
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	tx, err := s.db.NewTx()
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, roleID)
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
+	curTlSeq := curTl.Number()
+
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, roleID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2098,7 +1537,7 @@ func (s *CommandService) CircleAddDirectMember(ctx context.Context, roleID util.
 		return res, util.NilID, ErrValidation
 	}
 
-	role, err := s.readDB.Role(ctx, curTlSeq, roleID)
+	role, err := readDBService.Role(ctx, curTlSeq, roleID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2109,7 +1548,7 @@ func (s *CommandService) CircleAddDirectMember(ctx context.Context, roleID util.
 		return nil, util.NilID, errors.Errorf("role with id %s is not a circle", roleID)
 	}
 
-	member, err := s.readDB.Member(ctx, curTlSeq, memberID)
+	member, err := readDBService.Member(ctx, curTlSeq, memberID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2121,25 +1560,18 @@ func (s *CommandService) CircleAddDirectMember(ctx context.Context, roleID util.
 		return res, util.NilID, ErrValidation
 	}
 
-	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	command := commands.NewCommand(commands.CommandTypeCircleAddDirectMember, correlationID, causationID, callingMember.ID, &commands.CircleAddDirectMember{RoleID: roleID, MemberID: memberID})
 
-	events = append(events, eventstore.NewEventCircleDirectMemberAdded(roleID, memberID))
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
+	rtr := aggregate.NewRolesTreeRepository(s.dataDir, s.es, s.uidGenerator)
+	rt, err := rtr.Load(eventstore.RolesTreeAggregateID)
 	if err != nil {
-		return nil, util.NilID, err
+		return res, util.NilID, err
 	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
+
+	groupID, _, err := aggregate.ExecCommand(command, rt, s.es, s.uidGenerator)
+	if err != nil {
 		return nil, util.NilID, err
 	}
 
@@ -2149,14 +1581,24 @@ func (s *CommandService) CircleAddDirectMember(ctx context.Context, roleID util.
 func (s *CommandService) CircleRemoveDirectMember(ctx context.Context, roleID util.ID, memberID util.ID) (*change.GenericResult, util.ID, error) {
 	res := &change.GenericResult{}
 
-	curTl := s.readDB.CurTimeLine(ctx)
-	curTlSeq := curTl.Number()
-
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	tx, err := s.db.NewTx()
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, roleID)
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
+	curTlSeq := curTl.Number()
+
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, roleID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2166,7 +1608,7 @@ func (s *CommandService) CircleRemoveDirectMember(ctx context.Context, roleID ut
 		return res, util.NilID, ErrValidation
 	}
 
-	role, err := s.readDB.Role(ctx, curTlSeq, roleID)
+	role, err := readDBService.Role(ctx, curTlSeq, roleID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2177,7 +1619,7 @@ func (s *CommandService) CircleRemoveDirectMember(ctx context.Context, roleID ut
 		return nil, util.NilID, errors.Errorf("role with id %s is not a circle", roleID)
 	}
 
-	circleDirectMembersGroups, err := s.readDB.CircleDirectMembers(ctx, curTlSeq, []util.ID{roleID})
+	circleDirectMembersGroups, err := readDBService.CircleDirectMembers(ctx, curTlSeq, []util.ID{roleID})
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2193,25 +1635,18 @@ func (s *CommandService) CircleRemoveDirectMember(ctx context.Context, roleID ut
 		return nil, util.NilID, errors.Errorf("member with id %s is not a member of role %s", memberID, roleID)
 	}
 
-	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	command := commands.NewCommand(commands.CommandTypeCircleRemoveDirectMember, correlationID, causationID, callingMember.ID, &commands.CircleRemoveDirectMember{RoleID: roleID, MemberID: memberID})
 
-	events = append(events, eventstore.NewEventCircleDirectMemberRemoved(roleID, memberID))
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
+	rtr := aggregate.NewRolesTreeRepository(s.dataDir, s.es, s.uidGenerator)
+	rt, err := rtr.Load(eventstore.RolesTreeAggregateID)
 	if err != nil {
-		return nil, util.NilID, err
+		return res, util.NilID, err
 	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
+
+	groupID, _, err := aggregate.ExecCommand(command, rt, s.es, s.uidGenerator)
+	if err != nil {
 		return nil, util.NilID, err
 	}
 
@@ -2221,10 +1656,20 @@ func (s *CommandService) CircleRemoveDirectMember(ctx context.Context, roleID ut
 func (s *CommandService) CircleSetLeadLinkMember(ctx context.Context, roleID, memberID util.ID) (*change.GenericResult, util.ID, error) {
 	res := &change.GenericResult{}
 
-	curTl := s.readDB.CurTimeLine(ctx)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
 	curTlSeq := curTl.Number()
 
-	role, err := s.readDB.Role(ctx, curTlSeq, roleID)
+	role, err := readDBService.Role(ctx, curTlSeq, roleID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2240,20 +1685,20 @@ func (s *CommandService) CircleSetLeadLinkMember(ctx context.Context, roleID, me
 	}
 
 	// get the role parent circle
-	parentCircleGroups, err := s.readDB.RoleParent(ctx, curTlSeq, []util.ID{role.ID})
+	parentCircleGroups, err := readDBService.RoleParent(ctx, curTlSeq, []util.ID{role.ID})
 	if err != nil {
 		return nil, util.NilID, err
 	}
 	parentCircle := parentCircleGroups[role.ID]
 
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 	if err != nil {
 		return nil, util.NilID, err
 	}
 	// if the parent circle doesn't exists we are the root circle
 	// do special handling
 	if parentCircle == nil {
-		cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, role.ID)
+		cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, role.ID)
 		if err != nil {
 			return nil, util.NilID, err
 		}
@@ -2263,7 +1708,7 @@ func (s *CommandService) CircleSetLeadLinkMember(ctx context.Context, roleID, me
 			return res, util.NilID, ErrValidation
 		}
 	} else {
-		cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, parentCircle.ID)
+		cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, parentCircle.ID)
 		if err != nil {
 			return nil, util.NilID, err
 		}
@@ -2274,19 +1719,7 @@ func (s *CommandService) CircleSetLeadLinkMember(ctx context.Context, roleID, me
 		}
 	}
 
-	leadLinkRoleGroups, err := s.readDB.CircleCoreRole(ctx, curTlSeq, models.RoleTypeLeadLink, []util.ID{role.ID})
-	if err != nil {
-		return nil, util.NilID, err
-	}
-	leadLinkRole := leadLinkRoleGroups[role.ID]
-
-	leadLinkMemberEdgesGroups, err := s.readDB.RoleMemberEdges(ctx, curTlSeq, []util.ID{leadLinkRole.ID}, nil)
-	if err != nil {
-		return nil, util.NilID, err
-	}
-	leadLinkMemberEdges := leadLinkMemberEdgesGroups[leadLinkRole.ID]
-
-	member, err := s.readDB.Member(ctx, curTlSeq, memberID)
+	member, err := readDBService.Member(ctx, curTlSeq, memberID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2294,71 +1727,40 @@ func (s *CommandService) CircleSetLeadLinkMember(ctx context.Context, roleID, me
 		return nil, util.NilID, errors.Errorf("member with id %s doesn't exist", memberID)
 	}
 
-	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	command := commands.NewCommand(commands.CommandTypeCircleSetLeadLinkMember, correlationID, causationID, callingMember.ID, &commands.CircleSetLeadLinkMember{RoleID: roleID, MemberID: memberID})
 
-	// Remove previous lead link
-	if len(leadLinkMemberEdges) > 0 {
-		es, err := s.circleUnsetLeadLinkMember(ctx, curTl, role.ID)
-		if err != nil {
-			return nil, util.NilID, err
-		}
-		events = append(events, es...)
-	}
-
-	events = append(events, eventstore.NewEventCircleLeadLinkMemberSet(roleID, leadLinkRole.ID, memberID))
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
+	rtr := aggregate.NewRolesTreeRepository(s.dataDir, s.es, s.uidGenerator)
+	rt, err := rtr.Load(eventstore.RolesTreeAggregateID)
 	if err != nil {
-		return nil, util.NilID, err
+		return res, util.NilID, err
 	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
+
+	groupID, _, err := aggregate.ExecCommand(command, rt, s.es, s.uidGenerator)
+	if err != nil {
 		return nil, util.NilID, err
 	}
 
 	return res, groupID, nil
 }
 
-func (s *CommandService) circleUnsetLeadLinkMember(ctx context.Context, curTl *util.TimeLine, roleID util.ID) ([]eventstore.Event, error) {
-	curTlSeq := curTl.Number()
-	events := []eventstore.Event{}
-
-	leadLinkRoleGroups, err := s.readDB.CircleCoreRole(ctx, curTlSeq, models.RoleTypeLeadLink, []util.ID{roleID})
-	if err != nil {
-		return nil, err
-	}
-	leadLinkRole := leadLinkRoleGroups[roleID]
-
-	leadLinkMemberEdgesGroups, err := s.readDB.RoleMemberEdges(ctx, curTlSeq, []util.ID{leadLinkRole.ID}, nil)
-	if err != nil {
-		return nil, err
-	}
-	leadLinkMemberEdges := leadLinkMemberEdgesGroups[leadLinkRole.ID]
-	if len(leadLinkMemberEdges) == 0 {
-		// no member assigned as lead link, don't error, just do nothing
-		return nil, nil
-	}
-
-	events = append(events, eventstore.NewEventCircleLeadLinkMemberUnset(roleID, leadLinkRole.ID, leadLinkMemberEdges[0].Member.ID))
-
-	return events, nil
-}
-
 func (s *CommandService) CircleUnsetLeadLinkMember(ctx context.Context, roleID util.ID) (*change.GenericResult, util.ID, error) {
 	res := &change.GenericResult{}
 
-	curTl := s.readDB.CurTimeLine(ctx)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
 	curTlSeq := curTl.Number()
-	role, err := s.readDB.Role(ctx, curTlSeq, roleID)
+	role, err := readDBService.Role(ctx, curTlSeq, roleID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2374,20 +1776,20 @@ func (s *CommandService) CircleUnsetLeadLinkMember(ctx context.Context, roleID u
 	}
 
 	// get the role parent circle
-	parentCircleGroups, err := s.readDB.RoleParent(ctx, curTlSeq, []util.ID{role.ID})
+	parentCircleGroups, err := readDBService.RoleParent(ctx, curTlSeq, []util.ID{role.ID})
 	if err != nil {
 		return nil, util.NilID, err
 	}
 	parentCircle := parentCircleGroups[role.ID]
 
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 	if err != nil {
 		return nil, util.NilID, err
 	}
 	// if the parent circle doesn't exists we are the root circle
 	// do special handling
 	if parentCircle == nil {
-		cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, role.ID)
+		cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, role.ID)
 		if err != nil {
 			return nil, util.NilID, err
 		}
@@ -2397,7 +1799,7 @@ func (s *CommandService) CircleUnsetLeadLinkMember(ctx context.Context, roleID u
 			return res, util.NilID, ErrValidation
 		}
 	} else {
-		cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, parentCircle.ID)
+		cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, parentCircle.ID)
 		if err != nil {
 			return nil, util.NilID, err
 		}
@@ -2408,13 +1810,13 @@ func (s *CommandService) CircleUnsetLeadLinkMember(ctx context.Context, roleID u
 		}
 	}
 
-	leadLinkGroups, err := s.readDB.CircleCoreRole(ctx, curTlSeq, models.RoleTypeLeadLink, []util.ID{role.ID})
+	leadLinkGroups, err := readDBService.CircleCoreRole(ctx, curTlSeq, models.RoleTypeLeadLink, []util.ID{role.ID})
 	if err != nil {
 		return nil, util.NilID, err
 	}
 	leadLink := leadLinkGroups[role.ID]
 
-	leadLinkMemberEdgesGroups, err := s.readDB.RoleMemberEdges(ctx, curTlSeq, []util.ID{leadLink.ID}, nil)
+	leadLinkMemberEdgesGroups, err := readDBService.RoleMemberEdges(ctx, curTlSeq, []util.ID{leadLink.ID}, nil)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2424,29 +1826,18 @@ func (s *CommandService) CircleUnsetLeadLinkMember(ctx context.Context, roleID u
 		return res, util.NilID, nil
 	}
 
-	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	command := commands.NewCommand(commands.CommandTypeCircleUnsetLeadLinkMember, correlationID, causationID, callingMember.ID, &commands.CircleUnsetLeadLinkMember{RoleID: roleID})
 
-	es, err := s.circleUnsetLeadLinkMember(ctx, curTl, role.ID)
+	rtr := aggregate.NewRolesTreeRepository(s.dataDir, s.es, s.uidGenerator)
+	rt, err := rtr.Load(eventstore.RolesTreeAggregateID)
 	if err != nil {
-		return nil, util.NilID, err
+		return res, util.NilID, err
 	}
-	events = append(events, es...)
 
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
+	groupID, _, err := aggregate.ExecCommand(command, rt, s.es, s.uidGenerator)
 	if err != nil {
-		return nil, util.NilID, err
-	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
 		return nil, util.NilID, err
 	}
 
@@ -2456,10 +1847,20 @@ func (s *CommandService) CircleUnsetLeadLinkMember(ctx context.Context, roleID u
 func (s *CommandService) CircleSetCoreRoleMember(ctx context.Context, roleType models.RoleType, roleID, memberID util.ID, electionExpiration *time.Time) (*change.GenericResult, util.ID, error) {
 	res := &change.GenericResult{}
 
-	curTl := s.readDB.CurTimeLine(ctx)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
 	curTlSeq := curTl.Number()
 
-	role, err := s.readDB.Role(ctx, curTlSeq, roleID)
+	role, err := readDBService.Role(ctx, curTlSeq, roleID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2474,11 +1875,11 @@ func (s *CommandService) CircleSetCoreRoleMember(ctx context.Context, roleType m
 		return res, util.NilID, ErrValidation
 	}
 
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, role.ID)
+	cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, role.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2488,19 +1889,7 @@ func (s *CommandService) CircleSetCoreRoleMember(ctx context.Context, roleType m
 		return res, util.NilID, ErrValidation
 	}
 
-	coreRoleGroups, err := s.readDB.CircleCoreRole(ctx, curTlSeq, roleType, []util.ID{role.ID})
-	if err != nil {
-		return nil, util.NilID, err
-	}
-	coreRole := coreRoleGroups[role.ID]
-
-	coreRoleMemberEdgesGroups, err := s.readDB.RoleMemberEdges(ctx, curTlSeq, []util.ID{coreRole.ID}, nil)
-	if err != nil {
-		return nil, util.NilID, err
-	}
-	coreRoleMemberEdges := coreRoleMemberEdgesGroups[coreRole.ID]
-
-	member, err := s.readDB.Member(ctx, curTlSeq, memberID)
+	member, err := readDBService.Member(ctx, curTlSeq, memberID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2508,68 +1897,41 @@ func (s *CommandService) CircleSetCoreRoleMember(ctx context.Context, roleType m
 		return nil, util.NilID, errors.Errorf("member with id %s doesn't exist", memberID)
 	}
 
-	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	command := commands.NewCommand(commands.CommandTypeCircleSetCoreRoleMember, correlationID, causationID, callingMember.ID, &commands.CircleSetCoreRoleMember{RoleType: roleType, RoleID: roleID, MemberID: memberID, ElectionExpiration: electionExpiration})
 
-	// Remove previous core role member
-	if len(coreRoleMemberEdges) > 0 {
-		events = append(events, eventstore.NewEventCircleCoreRoleMemberUnset(role.ID, coreRole.ID, coreRoleMemberEdges[0].Member.ID, roleType))
-	}
-
-	events = append(events, eventstore.NewEventCircleCoreRoleMemberSet(role.ID, coreRole.ID, memberID, roleType, electionExpiration))
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
+	rtr := aggregate.NewRolesTreeRepository(s.dataDir, s.es, s.uidGenerator)
+	rt, err := rtr.Load(eventstore.RolesTreeAggregateID)
 	if err != nil {
-		return nil, util.NilID, err
+		return res, util.NilID, err
 	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
+
+	groupID, _, err := aggregate.ExecCommand(command, rt, s.es, s.uidGenerator)
+	if err != nil {
 		return nil, util.NilID, err
 	}
 
 	return res, groupID, nil
 }
 
-func (s *CommandService) circleUnsetCoreRoleMember(ctx context.Context, curTl *util.TimeLine, roleType models.RoleType, roleID util.ID) ([]eventstore.Event, error) {
-	curTlSeq := curTl.Number()
-	events := []eventstore.Event{}
-
-	coreRoleGroups, err := s.readDB.CircleCoreRole(ctx, curTlSeq, roleType, []util.ID{roleID})
-	if err != nil {
-		return nil, err
-	}
-	coreRole := coreRoleGroups[roleID]
-
-	coreRoleMemberEdgesGroups, err := s.readDB.RoleMemberEdges(ctx, curTlSeq, []util.ID{coreRole.ID}, nil)
-	if err != nil {
-		return nil, err
-	}
-	coreRoleMemberEdges := coreRoleMemberEdgesGroups[coreRole.ID]
-	if len(coreRoleMemberEdges) == 0 {
-		// no member assigned to core role, don't error, just do nothing
-		return nil, nil
-	}
-
-	events = append(events, eventstore.NewEventCircleCoreRoleMemberUnset(roleID, coreRole.ID, coreRoleMemberEdges[0].Member.ID, roleType))
-
-	return events, nil
-}
-
 func (s *CommandService) CircleUnsetCoreRoleMember(ctx context.Context, roleType models.RoleType, roleID util.ID) (*change.GenericResult, util.ID, error) {
 	res := &change.GenericResult{}
 
-	curTl := s.readDB.CurTimeLine(ctx)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
 	curTlSeq := curTl.Number()
 
-	role, err := s.readDB.Role(ctx, curTlSeq, roleID)
+	role, err := readDBService.Role(ctx, curTlSeq, roleID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2584,11 +1946,11 @@ func (s *CommandService) CircleUnsetCoreRoleMember(ctx context.Context, roleType
 		return res, util.NilID, ErrValidation
 	}
 
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, role.ID)
+	cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, role.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2598,13 +1960,13 @@ func (s *CommandService) CircleUnsetCoreRoleMember(ctx context.Context, roleType
 		return res, util.NilID, ErrValidation
 	}
 
-	coreRoleGroups, err := s.readDB.CircleCoreRole(ctx, curTlSeq, roleType, []util.ID{role.ID})
+	coreRoleGroups, err := readDBService.CircleCoreRole(ctx, curTlSeq, roleType, []util.ID{role.ID})
 	if err != nil {
 		return nil, util.NilID, err
 	}
 	coreRole := coreRoleGroups[role.ID]
 
-	coreRoleMemberEdgesGroups, err := s.readDB.RoleMemberEdges(ctx, curTlSeq, []util.ID{coreRole.ID}, nil)
+	coreRoleMemberEdgesGroups, err := readDBService.RoleMemberEdges(ctx, curTlSeq, []util.ID{coreRole.ID}, nil)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2614,29 +1976,18 @@ func (s *CommandService) CircleUnsetCoreRoleMember(ctx context.Context, roleType
 		return res, util.NilID, nil
 	}
 
-	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	command := commands.NewCommand(commands.CommandTypeCircleUnsetCoreRoleMember, correlationID, causationID, callingMember.ID, &commands.CircleUnsetCoreRoleMember{RoleType: roleType, RoleID: roleID})
 
-	es, err := s.circleUnsetCoreRoleMember(ctx, curTl, roleType, role.ID)
+	rtr := aggregate.NewRolesTreeRepository(s.dataDir, s.es, s.uidGenerator)
+	rt, err := rtr.Load(eventstore.RolesTreeAggregateID)
 	if err != nil {
-		return nil, util.NilID, err
+		return res, util.NilID, err
 	}
-	events = append(events, es...)
 
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
+	groupID, _, err := aggregate.ExecCommand(command, rt, s.es, s.uidGenerator)
 	if err != nil {
-		return nil, util.NilID, err
-	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
 		return nil, util.NilID, err
 	}
 
@@ -2654,10 +2005,20 @@ func (s *CommandService) RoleAddMember(ctx context.Context, roleID util.ID, memb
 		}
 	}
 
-	curTl := s.readDB.CurTimeLine(ctx)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
 	curTlSeq := curTl.Number()
 
-	role, err := s.readDB.Role(ctx, curTlSeq, roleID)
+	role, err := readDBService.Role(ctx, curTlSeq, roleID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2669,17 +2030,17 @@ func (s *CommandService) RoleAddMember(ctx context.Context, roleID util.ID, memb
 	}
 
 	// get the role parent circle
-	circleGroups, err := s.readDB.RoleParent(ctx, curTlSeq, []util.ID{role.ID})
+	circleGroups, err := readDBService.RoleParent(ctx, curTlSeq, []util.ID{role.ID})
 	if err != nil {
 		return nil, util.NilID, err
 	}
 	circle := circleGroups[role.ID]
 
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, circle.ID)
+	cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, circle.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2689,7 +2050,7 @@ func (s *CommandService) RoleAddMember(ctx context.Context, roleID util.ID, memb
 		return res, util.NilID, ErrValidation
 	}
 
-	roleMemberEdgesGroups, err := s.readDB.RoleMemberEdges(ctx, curTlSeq, []util.ID{roleID}, nil)
+	roleMemberEdgesGroups, err := readDBService.RoleMemberEdges(ctx, curTlSeq, []util.ID{roleID}, nil)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2702,7 +2063,7 @@ func (s *CommandService) RoleAddMember(ctx context.Context, roleID util.ID, memb
 		}
 	}
 
-	member, err := s.readDB.Member(ctx, curTlSeq, memberID)
+	member, err := readDBService.Member(ctx, curTlSeq, memberID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2710,25 +2071,18 @@ func (s *CommandService) RoleAddMember(ctx context.Context, roleID util.ID, memb
 		return nil, util.NilID, errors.Errorf("member with id %s doesn't exist", memberID)
 	}
 
-	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	command := commands.NewCommand(commands.CommandTypeRoleAddMember, correlationID, causationID, callingMember.ID, &commands.RoleAddMember{RoleID: roleID, MemberID: memberID, Focus: focus, NoCoreMember: noCoreMember})
 
-	events = append(events, eventstore.NewEventRoleMemberAdded(roleID, memberID, focus, noCoreMember))
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
+	rtr := aggregate.NewRolesTreeRepository(s.dataDir, s.es, s.uidGenerator)
+	rt, err := rtr.Load(eventstore.RolesTreeAggregateID)
 	if err != nil {
-		return nil, util.NilID, err
+		return res, util.NilID, err
 	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
+
+	groupID, _, err := aggregate.ExecCommand(command, rt, s.es, s.uidGenerator)
+	if err != nil {
 		return nil, util.NilID, err
 	}
 
@@ -2738,10 +2092,20 @@ func (s *CommandService) RoleAddMember(ctx context.Context, roleID util.ID, memb
 func (s *CommandService) RoleRemoveMember(ctx context.Context, roleID util.ID, memberID util.ID) (*change.GenericResult, util.ID, error) {
 	res := &change.GenericResult{}
 
-	curTl := s.readDB.CurTimeLine(ctx)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
 	curTlSeq := curTl.Number()
 
-	role, err := s.readDB.Role(ctx, curTlSeq, roleID)
+	role, err := readDBService.Role(ctx, curTlSeq, roleID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2753,17 +2117,17 @@ func (s *CommandService) RoleRemoveMember(ctx context.Context, roleID util.ID, m
 	}
 
 	// get the role parent circle
-	circleGroups, err := s.readDB.RoleParent(ctx, curTlSeq, []util.ID{role.ID})
+	circleGroups, err := readDBService.RoleParent(ctx, curTlSeq, []util.ID{role.ID})
 	if err != nil {
 		return nil, util.NilID, err
 	}
 	circle := circleGroups[role.ID]
 
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, circle.ID)
+	cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, circle.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2773,7 +2137,7 @@ func (s *CommandService) RoleRemoveMember(ctx context.Context, roleID util.ID, m
 		return res, util.NilID, ErrValidation
 	}
 
-	roleMembersGroups, err := s.readDB.RoleMemberEdges(ctx, curTlSeq, []util.ID{roleID}, nil)
+	roleMembersGroups, err := readDBService.RoleMemberEdges(ctx, curTlSeq, []util.ID{roleID}, nil)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2789,25 +2153,18 @@ func (s *CommandService) RoleRemoveMember(ctx context.Context, roleID util.ID, m
 		return nil, util.NilID, errors.Errorf("member with id %s is not a member of role %s", memberID, roleID)
 	}
 
-	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	command := commands.NewCommand(commands.CommandTypeRoleRemoveMember, correlationID, causationID, callingMember.ID, &commands.RoleRemoveMember{RoleID: roleID, MemberID: memberID})
 
-	events = append(events, eventstore.NewEventRoleMemberRemoved(roleID, memberID))
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
+	rtr := aggregate.NewRolesTreeRepository(s.dataDir, s.es, s.uidGenerator)
+	rt, err := rtr.Load(eventstore.RolesTreeAggregateID)
 	if err != nil {
-		return nil, util.NilID, err
+		return res, util.NilID, err
 	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
+
+	groupID, _, err := aggregate.ExecCommand(command, rt, s.es, s.uidGenerator)
+	if err != nil {
 		return nil, util.NilID, err
 	}
 
@@ -2825,10 +2182,20 @@ func (s *CommandService) RoleUpdateMember(ctx context.Context, roleID util.ID, m
 		}
 	}
 
-	curTl := s.readDB.CurTimeLine(ctx)
+	tx, err := s.db.NewTx()
+	if err != nil {
+		return nil, util.NilID, err
+	}
+	defer tx.Rollback()
+	readDBService, err := readdb.NewReadDBService(tx)
+	if err != nil {
+		return nil, util.NilID, err
+	}
+
+	curTl := readDBService.CurTimeLine(ctx)
 	curTlSeq := curTl.Number()
 
-	role, err := s.readDB.Role(ctx, curTlSeq, roleID)
+	role, err := readDBService.Role(ctx, curTlSeq, roleID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2841,17 +2208,17 @@ func (s *CommandService) RoleUpdateMember(ctx context.Context, roleID util.ID, m
 	}
 
 	// get the role parent circle
-	circleGroups, err := s.readDB.RoleParent(ctx, curTlSeq, []util.ID{role.ID})
+	circleGroups, err := readDBService.RoleParent(ctx, curTlSeq, []util.ID{role.ID})
 	if err != nil {
 		return nil, util.NilID, err
 	}
 	circle := circleGroups[role.ID]
 
-	callingMember, err := s.readDB.CallingMember(ctx, curTlSeq)
+	callingMember, err := readDBService.CallingMember(ctx, curTlSeq)
 	if err != nil {
 		return nil, util.NilID, err
 	}
-	cp, err := s.readDB.MemberCirclePermissions(ctx, curTlSeq, circle.ID)
+	cp, err := readDBService.MemberCirclePermissions(ctx, curTlSeq, circle.ID)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2861,7 +2228,7 @@ func (s *CommandService) RoleUpdateMember(ctx context.Context, roleID util.ID, m
 		return res, util.NilID, ErrValidation
 	}
 
-	roleMembersGroups, err := s.readDB.RoleMemberEdges(ctx, curTlSeq, []util.ID{roleID}, nil)
+	roleMembersGroups, err := readDBService.RoleMemberEdges(ctx, curTlSeq, []util.ID{roleID}, nil)
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2877,97 +2244,97 @@ func (s *CommandService) RoleUpdateMember(ctx context.Context, roleID util.ID, m
 		return nil, util.NilID, errors.Errorf("member with id %s is not a member of role %s", memberID, roleID)
 	}
 
-	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
-	if err != nil {
-		return nil, util.NilID, err
-	}
-
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
-
 	command := commands.NewCommand(commands.CommandTypeRoleUpdateMember, correlationID, causationID, callingMember.ID, &commands.RoleUpdateMember{RoleID: roleID, MemberID: memberID, Focus: focus, NoCoreMember: noCoreMember})
 
-	events = append(events, eventstore.NewEventRoleMemberUpdated(roleID, memberID, focus, noCoreMember))
-
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
+	rtr := aggregate.NewRolesTreeRepository(s.dataDir, s.es, s.uidGenerator)
+	rt, err := rtr.Load(eventstore.RolesTreeAggregateID)
 	if err != nil {
-		return nil, util.NilID, err
+		return res, util.NilID, err
 	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
+
+	groupID, _, err := aggregate.ExecCommand(command, rt, s.es, s.uidGenerator)
+	if err != nil {
 		return nil, util.NilID, err
 	}
 
 	return res, groupID, nil
 }
 
-func (s *CommandService) roleAddCoreRoles(role *models.Role, isRootRole bool) ([]eventstore.Event, error) {
-	events := []eventstore.Event{}
-
-	for _, coreRoleDefinition := range models.GetCoreRoles() {
-		coreRole := coreRoleDefinition.Role
-
-		if isRootRole {
-			// root role doesn't have a replink
-			if coreRole.RoleType == models.RoleTypeRepLink {
-				continue
-			}
-		}
-		coreRole.ID = s.uidGenerator.UUID(fmt.Sprintf("%s-%s", role.Name, coreRole.Name))
-
-		events = append(events, eventstore.NewEventRoleCreated(coreRole, &role.ID))
-
-		domains := coreRoleDefinition.Domains
-		for _, domain := range domains {
-			domain.ID = s.uidGenerator.UUID(fmt.Sprintf("%s-%s-%s", role.Name, coreRole.Name, domain.Description))
-			events = append(events, eventstore.NewEventRoleDomainCreated(coreRole.ID, domain))
-		}
-		accountabilities := coreRoleDefinition.Accountabilities
-		for _, accountability := range accountabilities {
-			accountability.ID = s.uidGenerator.UUID(fmt.Sprintf("%s-%s-%s", role.Name, coreRole.Name, accountability.Description))
-			events = append(events, eventstore.NewEventRoleAccountabilityCreated(coreRole.ID, accountability))
-		}
-	}
-
-	return events, nil
-}
-
-func (s *CommandService) SetupRootRole() (util.ID, error) {
-	role := &models.Role{
-		RoleType: models.RoleTypeCircle,
-		Name:     "General",
-	}
-
-	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
-	if err != nil {
-		return util.NilID, err
-	}
+func (s *CommandService) SetupRootRole() (util.ID, util.ID, error) {
+	rootRoleID := s.uidGenerator.UUID("RootRole")
 
 	correlationID := s.uidGenerator.UUID("")
 	causationID := s.uidGenerator.UUID("")
-	groupID := s.uidGenerator.UUID("")
-	events := []eventstore.Event{}
+	command := commands.NewCommand(commands.CommandTypeSetupRootRole, correlationID, causationID, util.NilID, &commands.SetupRootRole{RootRoleID: rootRoleID, Name: "General"})
 
-	command := commands.NewCommand(commands.CommandTypeSetupRootRole, correlationID, causationID, util.NilID, &commands.SetupRootRole{})
-
-	role.ID = s.uidGenerator.UUID("RootRole")
-
-	events = append(events, eventstore.NewEventRoleCreated(role, nil))
-
-	es, err := s.roleAddCoreRoles(role, true)
+	rtr := aggregate.NewRolesTreeRepository(s.dataDir, s.es, s.uidGenerator)
+	rt, err := rtr.Load(eventstore.RolesTreeAggregateID)
 	if err != nil {
-		return util.NilID, err
+		return util.NilID, util.NilID, err
 	}
-	events = append(events, es...)
 
-	wevents, err := s.writeEvents(events, command, groupID, eventstore.RolesTreeAggregate, eventstore.RolesTreeAggregateID.String(), version)
+	groupID, _, err := aggregate.ExecCommand(command, rt, s.es, s.uidGenerator)
 	if err != nil {
-		return util.NilID, err
-	}
-	if err := s.readDB.ApplyEvents(wevents); err != nil {
-		return util.NilID, err
+		return util.NilID, util.NilID, err
 	}
 
-	return role.ID, nil
+	return rootRoleID, groupID, nil
+}
+
+func (s *CommandService) waitMemberChangeRequest(ctx context.Context, memberChangeID util.ID) (util.ID, error) {
+	l := s.lnf.NewListener()
+
+	if err := l.Listen("event"); err != nil {
+		return util.NilID, err
+	}
+	defer l.Close()
+
+	var rerr error
+
+	for {
+		var v int64
+		for {
+			events, err := s.es.GetEvents(memberChangeID.String(), v+1, 100)
+			if err != nil {
+				return util.NilID, err
+			}
+
+			if len(events) == 0 {
+				break
+			}
+
+			v = events[len(events)-1].Version
+
+			for _, e := range events {
+				data, err := e.UnmarshalData()
+				if err != nil {
+					return util.NilID, err
+				}
+				metaData, err := e.UnmarshalMetaData()
+				if err != nil {
+					return util.NilID, err
+				}
+
+				if e.EventType == eventstore.EventTypeMemberChangeCompleted {
+					data := data.(*eventstore.EventMemberChangeCompleted)
+					if data.Error {
+						rerr = errors.New(data.Reason)
+						log.Debugf("request completed with error: %v", rerr)
+					}
+					groupID := *metaData.GroupID
+					return groupID, rerr
+				}
+			}
+		}
+		select {
+		case <-l.NotificationChannel():
+			continue
+		case <-time.After(1 * time.Second):
+			continue
+		case <-time.After(10 * time.Second):
+			return util.NilID, errors.Errorf("timeout waiting for completed memberChangeID: %s", memberChangeID)
+		}
+	}
 }

--- a/command/commands/commands.go
+++ b/command/commands/commands.go
@@ -27,6 +27,12 @@ const (
 
 	CommandTypeSetRoleAdditionalContent CommandType = "SetRoleAdditionalContent"
 
+	CommandTypeCompleteRequest CommandType = "CompleteRequest"
+
+	CommandTypeRequestCreateMember      CommandType = "RequestCreateMember"
+	CommandTypeRequestUpdateMember      CommandType = "RequestUpdateMember"
+	CommandTypeRequestSetMemberMatchUID CommandType = "RequestSetMemberMatchUID"
+
 	CommandTypeCreateMember      CommandType = "CreateMember"
 	CommandTypeUpdateMember      CommandType = "UpdateMember"
 	CommandTypeDeleteMember      CommandType = "DeleteMember"
@@ -50,6 +56,9 @@ const (
 	CommandTypeRoleAddMember    CommandType = "RoleAddMember"
 	CommandTypeRoleUpdateMember CommandType = "RoleUpdateMember"
 	CommandTypeRoleRemoveMember CommandType = "RoleRemoveMember"
+
+	CommandTypeReserveValue CommandType = "ReserveValue"
+	CommandTypeReleaseValue CommandType = "ReleaseValue"
 )
 
 type Command struct {
@@ -103,7 +112,13 @@ type SetRoleAdditionalContent struct {
 	Content string
 }
 
-type CreateMember struct {
+type CompleteRequest struct {
+	Error  bool
+	Reason string
+}
+
+type RequestCreateMember struct {
+	MemberID     util.ID
 	IsAdmin      bool
 	MatchUID     string
 	UserName     string
@@ -113,8 +128,9 @@ type CreateMember struct {
 	Avatar       []byte
 }
 
-func NewCommandCreateMember(c *change.CreateMemberChange, passwordHash string, avatar []byte) *CreateMember {
-	return &CreateMember{
+func NewCommandRequestCreateMember(c *change.CreateMemberChange, memberID util.ID, passwordHash string, avatar []byte) *RequestCreateMember {
+	return &RequestCreateMember{
+		MemberID:     memberID,
 		IsAdmin:      c.IsAdmin,
 		MatchUID:     c.MatchUID,
 		UserName:     c.UserName,
@@ -125,33 +141,90 @@ func NewCommandCreateMember(c *change.CreateMemberChange, passwordHash string, a
 	}
 }
 
-type UpdateMember struct {
-	ID       util.ID
-	IsAdmin  bool
-	UserName string
-	FullName string
-	Email    string
-	Avatar   []byte
+type CreateMember struct {
+	IsAdmin        bool
+	MatchUID       string
+	UserName       string
+	FullName       string
+	Email          string
+	PasswordHash   string
+	Avatar         []byte
+	MemberChangeID util.ID
 }
 
-func NewCommandUpdateMember(c *change.UpdateMemberChange, avatar []byte) *UpdateMember {
+func NewCommandCreateMember(c *change.CreateMemberChange, memberChangeID util.ID, passwordHash string, avatar []byte) *CreateMember {
+	return &CreateMember{
+		IsAdmin:        c.IsAdmin,
+		MatchUID:       c.MatchUID,
+		UserName:       c.UserName,
+		FullName:       c.FullName,
+		Email:          c.Email,
+		PasswordHash:   passwordHash,
+		Avatar:         avatar,
+		MemberChangeID: memberChangeID,
+	}
+}
+
+type RequestUpdateMember struct {
+	MemberID     util.ID
+	IsAdmin      bool
+	UserName     string
+	FullName     string
+	Email        string
+	Avatar       []byte
+	PrevUserName string
+	PrevEmail    string
+}
+
+func NewCommandRequestUpdateMember(c *change.UpdateMemberChange, memberID util.ID, avatar []byte, prevUserName, prevEmail string) *RequestUpdateMember {
+	return &RequestUpdateMember{
+		MemberID:     memberID,
+		IsAdmin:      c.IsAdmin,
+		UserName:     c.UserName,
+		FullName:     c.FullName,
+		Email:        c.Email,
+		Avatar:       avatar,
+		PrevUserName: prevUserName,
+		PrevEmail:    prevEmail,
+	}
+}
+
+type UpdateMember struct {
+	IsAdmin        bool
+	UserName       string
+	FullName       string
+	Email          string
+	Avatar         []byte
+	MemberChangeID util.ID
+	PrevUserName   string
+	PrevEmail      string
+}
+
+func NewCommandUpdateMember(c *change.UpdateMemberChange, memberChangeID util.ID, avatar []byte, prevUserName, prevEmail string) *UpdateMember {
 	return &UpdateMember{
-		IsAdmin:  c.IsAdmin,
-		UserName: c.UserName,
-		FullName: c.FullName,
-		Email:    c.Email,
-		Avatar:   avatar,
+		IsAdmin:        c.IsAdmin,
+		UserName:       c.UserName,
+		FullName:       c.FullName,
+		Email:          c.Email,
+		Avatar:         avatar,
+		MemberChangeID: memberChangeID,
+		PrevUserName:   prevUserName,
+		PrevEmail:      prevEmail,
 	}
 }
 
 type SetMemberPassword struct {
-	MemberID     util.ID
 	PasswordHash string
 }
 
-type SetMemberMatchUID struct {
+type RequestSetMemberMatchUID struct {
 	MemberID util.ID
 	MatchUID string
+}
+
+type SetMemberMatchUID struct {
+	MatchUID       string
+	MemberChangeID util.ID
 }
 
 type CreateTension struct {
@@ -254,4 +327,16 @@ type RoleUpdateMember struct {
 type RoleRemoveMember struct {
 	RoleID   util.ID
 	MemberID util.ID
+}
+
+type ReserveValue struct {
+	Value     string
+	ID        util.ID
+	RequestID util.ID
+}
+
+type ReleaseValue struct {
+	Value     string
+	ID        util.ID
+	RequestID util.ID
 }

--- a/common/locks.go
+++ b/common/locks.go
@@ -1,0 +1,5 @@
+package common
+
+const (
+	EventHandlersLockSpace = "eventhandlers"
+)

--- a/config/config.go
+++ b/config/config.go
@@ -28,9 +28,10 @@ func Parse(configFile string) (*Config, error) {
 type Config struct {
 	Debug bool `json:"debug"`
 
-	Web   Web   `json:"web"`
-	DB    DB    `json:"db"`
-	Index Index `json:"index"`
+	Web        Web        `json:"web"`
+	ReadDB     DB         `json:"readdb"`
+	EventStore EventStore `json:"eventStore"`
+	Index      Index      `json:"index"`
 
 	TokenSigning TokenSigning `json:"tokenSigning"`
 
@@ -81,6 +82,11 @@ type Web struct {
 type DB struct {
 	Type       db.Type `json:"type"`
 	ConnString string  `json:"connString"`
+}
+
+type EventStore struct {
+	Type string `json:"type"`
+	DB   DB     `json:"db"`
 }
 
 type Index struct {

--- a/db/db.go
+++ b/db/db.go
@@ -24,7 +24,7 @@ const (
 	Postgres    Type = "postgres"
 	CockRoachDB Type = "cockroachdb"
 
-	maxTxRetries = 30
+	maxTxRetries = 120
 )
 
 type dbData struct {
@@ -201,7 +201,7 @@ func (db *DB) Do(f func(tx *Tx) error) error {
 			if sqerr.Code == sqlite3.ErrBusy {
 				retries++
 				if retries < maxTxRetries {
-					time.Sleep(time.Duration(retries%10) * time.Millisecond)
+					time.Sleep(time.Duration(retries%30) * time.Millisecond)
 					continue
 				}
 			}
@@ -235,7 +235,7 @@ func (tx *Tx) Start() error {
 	}
 	switch tx.db.data.t {
 	case Postgres:
-		if _, err := wtx.Exec("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE"); err != nil {
+		if _, err := wtx.Exec("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"); err != nil {
 			return errors.WithStack(err)
 		}
 	}

--- a/db/migration.go
+++ b/db/migration.go
@@ -2,25 +2,34 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/pkg/errors"
 
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
-
-	"github.com/pkg/errors"
 )
 
-const migrationTableDDL = `
-	create table if not exists migration (version int not null, time timestamptz not null)
+// TODO(sgotti) as of https://github.com/cockroachdb/cockroach/pull/14368 it's not
+// possible to do statements after schema changes in the same transaction.
+// So cockroachdb won't work at the moment
+
+const migrationTableDDLTmpl = `
+	create table if not exists %s (version int not null, time timestamptz not null)
 `
 
-func (db *DB) Migrate() error {
+func (db *DB) Migrate(dbName string, migrations []Migration) error {
+	sb := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
+	migrationTable := fmt.Sprintf("migration_%s", dbName)
+
 	tx, err := db.NewTx()
 	if err != nil {
 		return err
 	}
 
 	err = tx.Do(func(tx *WrappedTx) error {
-		_, err = tx.Exec(migrationTableDDL)
+		_, err = tx.Exec(fmt.Sprintf(migrationTableDDLTmpl, migrationTable))
 		return err
 	})
 	if err != nil {
@@ -44,7 +53,11 @@ func (db *DB) Migrate() error {
 				version sql.NullInt64
 				n       int
 			)
-			if err := tx.QueryRow(`select max(version) from migration`).Scan(&version); err != nil {
+			q, args, err := sb.Select("max(version)").From(migrationTable).ToSql()
+			if err != nil {
+				return err
+			}
+			if err := tx.QueryRow(q, args...).Scan(&version); err != nil {
 				return errors.Wrap(err, "cannot get current migration version")
 			}
 			if version.Valid {
@@ -58,14 +71,17 @@ func (db *DB) Migrate() error {
 			migrationVersion := n + 1
 			m := migrations[n]
 
-			for _, stmt := range m.stmts {
+			for _, stmt := range m.Stmts {
 				if _, err := tx.Exec(stmt); err != nil {
 					return errors.Wrapf(err, "migration %d failed", migrationVersion)
 				}
 			}
 
-			q := `insert into migration (version, time) values ($1, now());`
-			if _, err := tx.Exec(q, migrationVersion); err != nil {
+			q, args, err = sb.Insert(migrationTable).Columns("version", "time").Values(migrationVersion, "now()").ToSql()
+			if err != nil {
+				return err
+			}
+			if _, err := tx.Exec(q, args...); err != nil {
 				return errors.Wrap(err, "failed to update migration table")
 			}
 			return nil
@@ -85,123 +101,6 @@ func (db *DB) Migrate() error {
 	return nil
 }
 
-type migration struct {
-	stmts []string
-}
-
-// TODO(sgotti) as of https://github.com/cockroachdb/cockroach/pull/14368 it's not
-// possible to do statements after schema changes in the same transaction.
-// So cockroachdb won't work at the moment
-
-// The statements are for the postgres db type
-var migrations = []migration{
-	{
-		stmts: []string{
-			// === EventStore ===
-			`--POSTGRES
-             create table event (id uuid not null, sequencenumber bigserial, eventtype varchar not null, category varchar not null, streamid varchar not null, timestamp timestamptz not null, version bigint not null, data bytea, metadata bytea, PRIMARY KEY (sequencenumber), UNIQUE (category, streamid, version))`,
-			`--SQLITE3
-             create table event (id uuid not null, sequencenumber INTEGER PRIMARY KEY AUTOINCREMENT, eventtype varchar not null, category varchar not null, streamid varchar not null, timestamp timestamptz not null, version bigint not null, data bytea, metadata bytea, UNIQUE (category, streamid, version))`,
-			"create index event_streamid on event(streamid, version)",
-			"create index event_category on event(category)",
-
-			// stores the latest version for every stream
-			"create table streamversion (streamid varchar not null, category varchar not null, version bigint not null, PRIMARY KEY(streamid))",
-
-			// === ReadDB ===
-
-			// processed events sequencenumbers
-			"create table sequencenumber (sequencenumber bigint, PRIMARY KEY(sequencenumber))",
-
-			// timeline
-			// we can end with different "events" happening at the same time
-			// (with millisecond precision for postgres), so timestamp cannot be
-			// unique.
-			"create table timeline (timestamp timestamptz not null, groupid uuid not null, aggregatetype varchar not null, aggregateid varchar not null, PRIMARY KEY(groupid))",
-			"create index timeline_ts on timeline(timestamp)",
-			"create index timeline_aggregatetype on timeline(aggregatetype)",
-			"create index timeline_aggregateid on timeline(aggregateid)",
-
-			// role is a one to many relation with child roles so it could be represented
-			// in the child role with a parent id. But, since we are implementing a time
-			// based db, we save the "edges" in a relation table so we have to just
-			// insert a new edge instead of inserting a full copy of the new child role
-			// timeline
-			//
-			// depth is used to be able to return values sorted by depth in the tree
-			// without computing the depth everytime (slow)
-			"create table role (id uuid, start_tl bigint, end_tl bigint, roletype varchar not null, depth int not null, name varchar, purpose varchar, PRIMARY KEY (id, start_tl))",
-			"create unique index role_tl on role(id, start_tl, end_tl DESC)",
-
-			"create table domain (id uuid, start_tl bigint, end_tl bigint, description varchar, PRIMARY KEY (id, start_tl))",
-			"create unique index domain_tl on domain(id, start_tl, end_tl DESC)",
-
-			"create table accountability (id uuid, start_tl bigint, end_tl bigint, description varchar, PRIMARY KEY (id, start_tl))",
-			"create unique index accountability_tl on accountability(id, start_tl, end_tl DESC)",
-
-			"create table roleadditionalcontent (id uuid, start_tl bigint, end_tl bigint, content varchar, PRIMARY KEY (id, start_tl))",
-			"create unique index roleadditionalcontent_tl on accountability(id, start_tl, end_tl DESC)",
-
-			// member
-			"create table member (id uuid, start_tl bigint, end_tl bigint, isadmin bool, username varchar, fullname varchar, email varchar, PRIMARY KEY (id, start_tl))",
-			"create unique index member_tl on member(id, start_tl, end_tl DESC)",
-
-			// id is the memberid
-			"create table memberavatar (id uuid, start_tl bigint, end_tl bigint, image bytea, PRIMARY KEY (id, start_tl))",
-			"create unique index memberavatar_tl on memberavatar(id, start_tl, end_tl DESC)",
-
-			"create table tension (id uuid, start_tl bigint, end_tl bigint, title varchar, description varchar, closed bool, closereason varchar, PRIMARY KEY (id, start_tl))",
-			"create unique index tension_tl on tension(id, start_tl, end_tl DESC)",
-
-			// edges
-			"create table rolerole (start_tl bigint, end_tl bigint, x uuid, y uuid)", // x: parent role id, y: child role id
-			"create index rolerole_x_start_tl on rolerole(x, start_tl, end_tl DESC)",
-			"create index rolerole_y_start_tl on rolerole(y, start_tl, end_tl DESC)",
-
-			"create table roledomain (start_tl bigint, end_tl bigint, x uuid, y uuid)", // x: domain id, y: role id
-			"create index roledomain_x_start_tl on roledomain(x, start_tl, end_tl DESC)",
-			"create index roledomain_y_start_tl on roledomain(y, start_tl, end_tl DESC)",
-
-			"create table roleaccountability (start_tl bigint, end_tl bigint, x uuid, y uuid)", // x: accountability id, y: role id
-			"create index roleaccountability_x_start_tl on roleaccountability(x, start_tl, end_tl DESC)",
-			"create index roleaccountability_y_start_tl on roleaccountability(y, start_tl, end_tl DESC)",
-
-			"create table circledirectmember (start_tl bigint, end_tl bigint, x uuid, y uuid)", // x: member id, y: role id
-			"create index circledirectmember_x_start_tl on circledirectmember(x, start_tl, end_tl DESC)",
-			"create index circledirectmember_y_start_tl on circledirectmember(y, start_tl, end_tl DESC)",
-
-			"create table rolemember (start_tl bigint, end_tl bigint, x uuid, y uuid, focus varchar, nocoremember bool, electionexpiration timestamptz)", // x: member id, y: role id
-			"create index rolemember_x_start_tl on rolemember(x, start_tl, end_tl DESC)",
-			"create index rolemember_y_start_tl on rolemember(y, start_tl, end_tl DESC)",
-
-			"create table membertension (start_tl bigint, end_tl bigint, x uuid, y uuid)", // x: tension id, y: member id
-			"create index membertension_x_start_tl on membertension(x, start_tl, end_tl DESC)",
-			"create index membertension_y_start_tl on membertension(y, start_tl, end_tl DESC)",
-
-			"create table roletension (start_tl bigint, end_tl bigint, x uuid, y uuid)", // x: tension id, y: role id
-			"create index roletension_x_start_tl on roletension(x, start_tl, end_tl DESC)",
-			"create index roletension_y_start_tl on roletension(y, start_tl, end_tl DESC)",
-
-			// read side events splitted in commands, per role and per member
-			"create table commandevent (timeline bigint, id uuid, issuer uuid, commandtype varchar, data bytea)",
-			"create table roleevent (timeline bigint, id uuid, command uuid, cause uuid, eventtype varchar, roleid uuid, data bytea)",
-			"create table memberevent (timeline bigint, id uuid, command uuid, cause uuid, eventtype varchar, memberid uuid, data bytea)",
-
-			// auth
-
-			// local passwords
-			"create table password (memberid uuid, password varchar)",
-
-			// NOTE while uuid is the local member unique id we also have a
-			// matchuid, it's used when using a non local authentication to
-			// match a attribute/claim reported by the authenticator to a local
-			// member.
-			// This value could be left empty when manually creating a member
-			// and only using local auth. Instead it's required when using or
-			// migrating to an external authentication mechanism.
-			// It'll be automatically populated when using a memberprovider to
-			// automatically create/update members.
-			"create table membermatch (memberid uuid, matchuid varchar)",
-		},
-	},
+type Migration struct {
+	Stmts []string
 }

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -9,18 +9,11 @@ We were primarily focused on the Sircles core and created sircles also as a test
 
 The backend is the core of sircles, it exposes a GraphQL API so everyone can implement its own client or tools around it.
 
-We are implementing a simple (and probably not really compliant with some CQRS best practices) CQRS and event sourcing based architecture.
+We are implementing a CQRS and event sourcing based architecture.
 
 We split the command services from the read services. So the commands (that comes from GraphQL mutations or internal changes) are validated and trigger the creation of some events. The events are the source of truth of the aggregates states. These events are then processed by the read database that applies the related changes to its view.
 
-We used a simpler (and less scalable since we don't need to scale so much) model:
-
-* The eventstore and the read database lives on the same database (now a sql like postgres, sqlite). In this way the flow that starts from a mutation to the generation of events and the application of the events to the read database are done inside the same (serializable) transaction. In this way we simplified different things:
-
-* The ui, after a successful mutation will update and found the updated data (in the react ui we could also do, thanks to the react apollo framework, optimistic updates and polling on some queries but this is left for the future if really needed)
-* We catch at runtime if the generated events causes problems on the read view. Of course this should (and is) tested inside integration tests but for the moment is a good life saver to avoid possible corruptions that will require rewriting the events and reappling them or rolling back some changes.
-
-* In addition the command part uses, as the aggregate state snapshot, the same read database (in future we could split them but now, to speed up development and testing, we used the same).
+For all details about the implementation we're going to detail them in different blog posts and future documentation.
 
 
 ### Read database architecture

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -27,15 +27,29 @@ web:
   #allowedOrigins:
   #  - '*'
 
-db:
-  # the database type (postgres or sqlite3), use postgres for production and
+readdb:
+  # the read database type (postgres or sqlite3), use postgres for production and
   # sqlite only for test
   type: 'postgres'
   # an example connection string to a postgres database instance on a sircles db
-  connString: 'postgres://user@db01/sircles?sslmode=disable'
-
+  connString: 'postgres://user@db01/sircles_readdb?sslmode=disable'
+  #
   #type: 'sqlite3'
   #connString: './sircles.db'
+
+eventStore:
+  # The eventstore type, currently only a sql based eventstore is supported
+  type: 'sql'
+  db:
+    # the eventstore sql database type (postgres or sqlite3), use postgres for
+    # production and sqlite only for test
+    type: 'postgres'
+    # an example connection string to a postgres database instance on a sircles db
+    connString: 'postgres://@localhost/sircles_es?sslmode=disable'
+    #
+    #type: 'sqlite3'
+    #connString: './sircles.db'
+
 
 ## index configuration
 index:
@@ -61,7 +75,7 @@ authentication:
 
 # type can be: local, ldap, oidc
   type: local
-    # the user should provided the email instead of the username for authentication
+    # the user should provide the email instead of the username for authentication
     #useEmail: true
 
 #  # example ldap configuration

--- a/eventhandler/deletedroletensionhandler.go
+++ b/eventhandler/deletedroletensionhandler.go
@@ -1,0 +1,415 @@
+package eventhandler
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/pkg/errors"
+	"github.com/sorintlab/sircles/aggregate"
+	"github.com/sorintlab/sircles/command/commands"
+	"github.com/sorintlab/sircles/common"
+	"github.com/sorintlab/sircles/db"
+	"github.com/sorintlab/sircles/eventstore"
+	"github.com/sorintlab/sircles/models"
+	"github.com/sorintlab/sircles/util"
+)
+
+const (
+	dbName = "drth.db"
+)
+
+func newDB(dataDir string) (*db.DB, error) {
+	return db.NewDB("sqlite3", filepath.Join(dataDir, dbName))
+}
+
+type DeletedRoleTensionHandler struct {
+	dataDir      string
+	es           *eventstore.EventStore
+	uidGenerator common.UIDGenerator
+}
+
+func NewDeletedRoleTensionHandler(dataDir string, es *eventstore.EventStore, uidGenerator common.UIDGenerator) (*DeletedRoleTensionHandler, error) {
+	ldb, err := newDB(dataDir)
+	if err != nil {
+		return nil, err
+	}
+	defer ldb.Close()
+
+	err = ldb.Do(func(tx *db.Tx) error {
+		return tx.Do(func(tx *db.WrappedTx) error {
+			for _, stmt := range drthDBCreateStmts {
+				if _, err := tx.Exec(stmt); err != nil {
+					return errors.WithMessage(err, "create failed")
+				}
+			}
+			return nil
+		})
+	})
+
+	return &DeletedRoleTensionHandler{
+		dataDir:      dataDir,
+		es:           es,
+		uidGenerator: uidGenerator,
+	}, err
+}
+
+func (h *DeletedRoleTensionHandler) Name() string {
+	return "deletedRoleTensionHandler"
+}
+
+func (h *DeletedRoleTensionHandler) updateTensions(ldb *db.DB) error {
+	var tensions map[util.ID]int64
+	err := ldb.Do(func(tx *db.Tx) error {
+		var err error
+		tensions, err = h.findTensions(tx)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	for tid, version := range tensions {
+		tr := aggregate.NewTensionRepository(h.es, h.uidGenerator)
+		t, err := tr.Load(tid)
+		if err != nil {
+			return err
+		}
+		correlationID := h.uidGenerator.UUID("")
+		causationID := h.uidGenerator.UUID("")
+		command := commands.NewCommand(commands.CommandTypeChangeTensionRole, correlationID, causationID, util.NilID, commands.NewCommandChangeTensionRole(nil, version))
+
+		events, err := t.HandleCommand(command)
+		if err != nil {
+			return err
+		}
+
+		groupID := h.uidGenerator.UUID("")
+		eventsData, err := eventstore.GenEventData(events, &correlationID, &causationID, &groupID, nil)
+		if err != nil {
+			return err
+		}
+		if _, err = h.es.WriteEvents(eventsData, t.AggregateType().String(), t.ID(), t.Version()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *DeletedRoleTensionHandler) HandleEvents() error {
+	log.Debugf("eh handleEvents")
+	ldb, err := newDB(h.dataDir)
+	if err != nil {
+		return err
+	}
+	defer ldb.Close()
+
+	for {
+		var n int
+		err := ldb.Do(func(tx *db.Tx) error {
+			var err error
+			n, err = h.updateSnapshot(tx)
+			return err
+		})
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			break
+		}
+	}
+
+	return h.updateTensions(ldb)
+}
+
+func (h *DeletedRoleTensionHandler) updateSnapshot(tx *db.Tx) (int, error) {
+	log.Debugf("updateSnapshot")
+
+	sn, err := h.SequenceNumber(tx)
+	if err != nil {
+		return 0, err
+	}
+	log.Debugf("sn: %d", sn)
+
+	events, err := h.es.GetAllEvents(sn+1, 100)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, e := range events {
+		if err := h.handleEvent(tx, e); err != nil {
+			return 0, err
+		}
+	}
+
+	sn, err = h.SequenceNumber(tx)
+	if err != nil {
+		return 0, err
+	}
+	log.Debugf("sn: %d", sn)
+
+	return len(events), nil
+}
+
+func (h *DeletedRoleTensionHandler) handleEvent(tx *db.Tx, event *eventstore.StoredEvent) error {
+	log.Debugf("event: %v", event)
+
+	data, err := event.UnmarshalData()
+	if err != nil {
+		return err
+	}
+
+	switch event.EventType {
+	case eventstore.EventTypeRoleCreated:
+
+	case eventstore.EventTypeRoleUpdated:
+		data := data.(*eventstore.EventRoleUpdated)
+		switch data.RoleType {
+		case models.RoleTypeCircle:
+			if err := h.deleteDeletedRole(tx, data.RoleID); err != nil {
+				return err
+			}
+		default:
+			if err := h.insertDeletedRole(tx, data.RoleID); err != nil {
+				return err
+			}
+		}
+
+	case eventstore.EventTypeRoleDeleted:
+		data := data.(*eventstore.EventRoleDeleted)
+		if err := h.insertDeletedRole(tx, data.RoleID); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeTensionCreated:
+		data := data.(*eventstore.EventTensionCreated)
+		tensionID, err := util.IDFromString(event.StreamID)
+		if err != nil {
+			return err
+		}
+		if err := h.updateTension(tx, tensionID, event.Version, data.RoleID); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeTensionRoleChanged:
+		data := data.(*eventstore.EventTensionRoleChanged)
+		tensionID, err := util.IDFromString(event.StreamID)
+		if err != nil {
+			return err
+		}
+		if err := h.updateTension(tx, tensionID, event.Version, data.RoleID); err != nil {
+			return err
+		}
+
+	case eventstore.EventTypeTensionClosed:
+		tensionID, err := util.IDFromString(event.StreamID)
+		if err != nil {
+			return err
+		}
+		if err := h.deleteTension(tx, tensionID); err != nil {
+			return err
+		}
+	}
+
+	// for every tension event update tension version if tension exists
+	if event.Category == eventstore.TensionAggregate.String() {
+		tensionID, err := util.IDFromString(event.StreamID)
+		if err != nil {
+			return err
+		}
+		if err := h.updateTensionVersion(tx, tensionID, event.Version); err != nil {
+			return err
+		}
+	}
+
+	if err := h.updateSequenceNumber(tx, event.SequenceNumber); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeletedRoleTensionHandler snapshot db
+var drthDBCreateStmts = []string{
+	"create table if not exists deletedrole (id uuid, PRIMARY KEY (id))",
+	"create table if not exists tension (id uuid, version bigint, roleid uuid, PRIMARY KEY (id))",
+	"create table if not exists sequencenumber (sequencenumber bigint)",
+}
+
+var (
+	sb = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
+
+	deletesRoleSelect = sb.Select("id").From("deletedrole")
+	deletesRoleInsert = sb.Insert("deletedrole").Columns("id")
+	deletesRoleDelete = sb.Delete("deletedrole")
+	deletesRoleUpdate = sb.Update("deletedrole")
+
+	tensionSelect = sb.Select("id", "roleid", "version").From("tension")
+	tensionInsert = sb.Insert("tension").Columns("id", "version", "roleid")
+	tensionDelete = sb.Delete("tension")
+	tensionUpdate = sb.Update("tension")
+
+	sequenceNumberSelect = sb.Select("sequencenumber").From("sequencenumber")
+	sequenceNumberInsert = sb.Insert("sequencenumber").Columns("sequencenumber")
+	sequenceNumberDelete = sb.Delete("sequencenumber")
+)
+
+func (h *DeletedRoleTensionHandler) findTensions(tx *db.Tx) (map[util.ID]int64, error) {
+	q, args, err := sb.Select("t.id, t.version").From("tension as t").Join("deletedrole as r on t.roleid = r.id").ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build query")
+	}
+
+	tensions := map[util.ID]int64{}
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		rows, err := tx.Query(q, args...)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute query")
+		}
+		for rows.Next() {
+			var tid util.ID
+			var version int64
+			if err := rows.Scan(&tid, &version); err != nil {
+				return errors.Wrap(err, "failed to scan rows")
+			}
+			tensions[tid] = version
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to find tension assigned to deleted role")
+	}
+	return tensions, nil
+}
+
+func (h *DeletedRoleTensionHandler) insertDeletedRole(tx *db.Tx, id util.ID) error {
+	if err := h.deleteDeletedRole(tx, id); err != nil {
+		return err
+	}
+
+	q, args, err := deletesRoleInsert.Values(id).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.WithMessage(err, fmt.Sprintf("failed to insert deleted role %s", id))
+	}
+	return nil
+}
+
+func (h *DeletedRoleTensionHandler) deleteDeletedRole(tx *db.Tx, id util.ID) error {
+	q, args, err := deletesRoleDelete.Where(sq.Eq{"id": id}).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.WithMessage(err, fmt.Sprintf("failed to delete deleted role %s", id))
+	}
+	return nil
+}
+
+func (h *DeletedRoleTensionHandler) updateTension(tx *db.Tx, id util.ID, version int64, roleID *util.ID) error {
+	if err := h.deleteTension(tx, id); err != nil {
+		return err
+	}
+
+	q, args, err := tensionInsert.Values(id, version, roleID).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.WithMessage(err, fmt.Sprintf("failed to insert tension %s", id))
+	}
+	return nil
+}
+
+func (h *DeletedRoleTensionHandler) deleteTension(tx *db.Tx, id util.ID) error {
+	q, args, err := tensionDelete.Where(sq.Eq{"id": id}).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.WithMessage(err, fmt.Sprintf("failed to delete tension %s", id))
+	}
+	return nil
+}
+func (h *DeletedRoleTensionHandler) updateTensionVersion(tx *db.Tx, id util.ID, version int64) error {
+	q, args, err := sb.Update("tension").Set("version", version).Where(sq.Eq{"id": id}).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.WithMessage(err, fmt.Sprintf("failed to update tension %s version", id))
+	}
+	return nil
+}
+
+func (h *DeletedRoleTensionHandler) SequenceNumber(tx *db.Tx) (int64, error) {
+	var sn int64
+	err := tx.Do(func(tx *db.WrappedTx) error {
+		return tx.QueryRow("select sequencenumber from sequencenumber limit 1").Scan(&sn)
+	})
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return sn, nil
+}
+
+func (h *DeletedRoleTensionHandler) updateSequenceNumber(tx *db.Tx, sn int64) error {
+	q, args, err := sequenceNumberDelete.ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.WithMessage(err, fmt.Sprintf("failed to delete sequencenumber: %v", sn))
+	}
+
+	q, args, err = sequenceNumberInsert.Values(sn).ToSql()
+	if err != nil {
+		return errors.Wrap(err, "failed to build query")
+	}
+
+	err = tx.Do(func(tx *db.WrappedTx) error {
+		_, err = tx.Exec(q, args...)
+		return err
+	})
+	if err != nil {
+		return errors.WithMessage(err, fmt.Sprintf("failed to insert sequencenumber: %v", sn))
+	}
+	return nil
+}

--- a/eventhandler/eventhandler.go
+++ b/eventhandler/eventhandler.go
@@ -1,0 +1,59 @@
+package eventhandler
+
+import (
+	"time"
+
+	ln "github.com/sorintlab/sircles/listennotify"
+	"github.com/sorintlab/sircles/lock"
+)
+
+type EventHandler interface {
+	HandleEvents() error
+	Name() string
+}
+
+func RunEventHandler(eh EventHandler, stop chan struct{}, lnf ln.ListenerFactory, lkf lock.LockFactory) (chan struct{}, error) {
+	l := lnf.NewListener()
+
+	if err := l.Listen("event"); err != nil {
+		return nil, err
+	}
+
+	nCh := l.NotificationChannel()
+	endCh := make(chan struct{})
+
+	go func() {
+		for {
+			// Take a distributed lock to avoid multiple instances handling the
+			// same events. Note that this won't create real issues but various
+			// errors could be logged since one of the instances will fail to
+			// handle events already handled by the other instance (i.e.
+			// concurrent update errors on the event stream, unique violations
+			// in the readdb etc...)
+			lk := lkf.NewLock(eh.Name())
+			if err := lk.Lock(); err != nil {
+				log.Errorf("failed to acquire lock: %+v", err)
+			} else {
+				if err := eh.HandleEvents(); err != nil {
+					log.Errorf("eventhandler HandleEvents error: %+v", err)
+				}
+				lk.Unlock()
+			}
+			select {
+			case <-nCh:
+				continue
+
+			case <-time.After(10 * time.Second):
+				go l.Ping()
+				continue
+
+			case <-stop:
+				l.Close()
+				close(endCh)
+				return
+			}
+		}
+	}()
+
+	return endCh, nil
+}

--- a/eventhandler/log.go
+++ b/eventhandler/log.go
@@ -1,0 +1,7 @@
+package eventhandler
+
+import (
+	slog "github.com/sorintlab/sircles/log"
+)
+
+var log = slog.S()

--- a/eventhandler/memberrequesthandler.go
+++ b/eventhandler/memberrequesthandler.go
@@ -1,0 +1,186 @@
+package eventhandler
+
+import (
+	"fmt"
+
+	"github.com/sorintlab/sircles/common"
+	"github.com/sorintlab/sircles/eventstore"
+	"github.com/sorintlab/sircles/saga"
+	"github.com/sorintlab/sircles/util"
+)
+
+type MemberRequestHandler struct {
+	es           *eventstore.EventStore
+	uidGenerator common.UIDGenerator
+}
+
+func NewMemberRequestHandler(es *eventstore.EventStore, uidGenerator common.UIDGenerator) *MemberRequestHandler {
+	log.Debugf("NewMemberRequestHandler")
+	return &MemberRequestHandler{
+		es:           es,
+		uidGenerator: uidGenerator,
+	}
+}
+
+func (r *MemberRequestHandler) Name() string {
+	return "memberRequestHandler"
+}
+
+func (r *MemberRequestHandler) HandleEvents() error {
+	log.Debugf("HandleEvents")
+
+	for {
+		event, err := r.es.GetLastEvent(eventstore.MemberRequestHandlerID.String())
+		if err != nil {
+			return err
+		}
+
+		var curMCSn, curMSn int64
+		var version int64
+
+		if event != nil {
+			data, err := event.UnmarshalData()
+			if err != nil {
+				return err
+			}
+
+			curMCSn = data.(*eventstore.EventMemberRequestHandlerStateUpdated).MemberChangeSequenceNumber
+			curMSn = data.(*eventstore.EventMemberRequestHandlerStateUpdated).MemberSequenceNumber
+			version = event.Version
+		}
+
+		log.Debugf("curMCSn: %d", curMCSn)
+		log.Debugf("curMSn: %d", curMSn)
+
+		mcEvents, err := r.es.GetEventsByCategory(eventstore.MemberChangeAggregate.String(), curMCSn+1, 100)
+		if err != nil {
+			return err
+		}
+		mEvents, err := r.es.GetEventsByCategory(eventstore.MemberAggregate.String(), curMSn+1, 100)
+		if err != nil {
+			return err
+		}
+
+		if len(mcEvents) == 0 && len(mEvents) == 0 {
+			break
+		}
+
+		mcSn := curMCSn
+		mSn := curMSn
+
+		for _, e := range mcEvents {
+			if err := r.handleEvent(e); err != nil {
+				return err
+			}
+			mcSn = e.SequenceNumber
+		}
+		for _, e := range mEvents {
+			if err := r.handleEvent(e); err != nil {
+				return err
+			}
+			mSn = e.SequenceNumber
+		}
+		log.Debugf("mcSn: %d", mcSn)
+		log.Debugf("mSn: %d", mSn)
+
+		if mcSn != curMCSn || mSn != curMSn {
+			stateEvent := eventstore.NewEventMemberRequestHandlerStateUpdated(mcSn, mSn)
+
+			eventsData, err := eventstore.GenEventData([]eventstore.Event{stateEvent}, nil, nil, nil, nil)
+			if err != nil {
+				return err
+			}
+
+			if _, err = r.es.WriteEvents(eventsData, eventstore.MemberRequestHandlerAggregate.String(), eventstore.MemberRequestHandlerID.String(), version); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *MemberRequestHandler) handleEvent(event *eventstore.StoredEvent) error {
+	log.Debugf("event: %v", event)
+
+	data, err := event.UnmarshalData()
+	if err != nil {
+		return err
+	}
+
+	switch event.EventType {
+	case eventstore.EventTypeMemberChangeCreateRequested:
+		memberChangeID, err := util.IDFromString(event.StreamID)
+		if err != nil {
+			return err
+		}
+		return r.callSaga(memberChangeID, event)
+
+	case eventstore.EventTypeMemberChangeUpdateRequested:
+		memberChangeID, err := util.IDFromString(event.StreamID)
+		if err != nil {
+			return err
+		}
+		return r.callSaga(memberChangeID, event)
+
+	case eventstore.EventTypeMemberChangeSetMatchUIDRequested:
+		memberChangeID, err := util.IDFromString(event.StreamID)
+		if err != nil {
+			return err
+		}
+		return r.callSaga(memberChangeID, event)
+
+	case eventstore.EventTypeMemberChangeCompleted:
+		memberChangeID, err := util.IDFromString(event.StreamID)
+		if err != nil {
+			return err
+		}
+		return r.callSaga(memberChangeID, event)
+
+	case eventstore.EventTypeMemberCreated:
+		data := data.(*eventstore.EventMemberCreated)
+		return r.callSaga(data.MemberChangeID, event)
+
+	case eventstore.EventTypeMemberUpdated:
+		data := data.(*eventstore.EventMemberUpdated)
+		return r.callSaga(data.MemberChangeID, event)
+
+	case eventstore.EventTypeMemberMatchUIDSet:
+		data := data.(*eventstore.EventMemberMatchUIDSet)
+		return r.callSaga(data.MemberChangeID, event)
+	}
+
+	return nil
+}
+
+func (r *MemberRequestHandler) callSaga(memberChangeID util.ID, event *eventstore.StoredEvent) error {
+	metaData, err := event.UnmarshalMetaData()
+	if err != nil {
+		return err
+	}
+
+	sr := saga.NewMemberRequestSagaRepository(r.es, r.uidGenerator)
+	// load saga assigned to the member change
+	saganame := fmt.Sprintf("memberrequestsaga-%s", memberChangeID)
+	s, err := sr.Load(saganame)
+	if err != nil {
+		return err
+	}
+
+	events, err := s.HandleEvent(event)
+	if err != nil {
+		return err
+	}
+
+	causationID := event.ID
+	correlationID := *metaData.CorrelationID
+	groupID := r.uidGenerator.UUID("")
+	eventsData, err := eventstore.GenEventData(events, &correlationID, &causationID, &groupID, nil)
+	if err != nil {
+		return err
+	}
+	if _, err = r.es.WriteEvents(eventsData, eventstore.MemberRequestSagaAggregate.String(), saganame, s.Version()); err != nil {
+		return err
+	}
+	return nil
+}

--- a/eventstore/event.go
+++ b/eventstore/event.go
@@ -136,12 +136,12 @@ const (
 type EventType string
 
 const (
-	// RolesTree Root Aggregate
+	// RolesTree Aggregate
 	// If we want to have transactional consistency between the roles and the
 	// hierarchy (to achieve ui transactional commands like update role that
-	// want to both update a role data and move role from/to it) the simplest
-	// way is to make the hierarchy and all it's roles as a single aggregate
-	// root.
+	// want to transactionally update a role data and move role from/to it) the
+	// simplest way is to make the hierarchy and all its roles as a single
+	// aggregate.
 	EventTypeRoleCreated EventType = "RoleCreated"
 	EventTypeRoleUpdated EventType = "RoleUpdated"
 	EventTypeRoleDeleted EventType = "RoleDeleted"

--- a/eventstore/event.go
+++ b/eventstore/event.go
@@ -434,10 +434,10 @@ type EventRoleAdditionalContentSet struct {
 	Content string
 }
 
-func NewEventRoleAdditionalContentSet(roleID util.ID, roleAdditionalContent *models.RoleAdditionalContent) *EventRoleAdditionalContentSet {
+func NewEventRoleAdditionalContentSet(roleID util.ID, content string) *EventRoleAdditionalContentSet {
 	return &EventRoleAdditionalContentSet{
 		RoleID:  roleID,
-		Content: roleAdditionalContent.Content,
+		Content: content,
 	}
 }
 

--- a/eventstore/event.go
+++ b/eventstore/event.go
@@ -16,6 +16,8 @@ var (
 	SircleUUIDNamespace, _ = uuid.FromString("6c4a36ae-1f5c-11e7-93ae-92361f002671")
 
 	RolesTreeAggregateID = util.NewFromUUID(uuid.NewV5(SircleUUIDNamespace, string(RolesTreeAggregate)))
+
+	MemberRequestHandlerID = util.NewFromUUID(uuid.NewV5(SircleUUIDNamespace, string(MemberRequestHandlerAggregate)))
 )
 
 type StoredEvent struct {
@@ -122,6 +124,12 @@ const (
 	RolesTreeAggregate AggregateType = "rolestree"
 	MemberAggregate    AggregateType = "member"
 	TensionAggregate   AggregateType = "tension"
+
+	MemberChangeAggregate         AggregateType = "memberchange"
+	MemberRequestHandlerAggregate AggregateType = "memberrequesthandler"
+	MemberRequestSagaAggregate    AggregateType = "memberrequestsaga"
+
+	UniqueValueRegistryAggregate AggregateType = "uniquevalueregistry"
 )
 
 // EventType is an event triggered by a command
@@ -163,7 +171,13 @@ const (
 	EventTypeCircleCoreRoleMemberSet   EventType = "CircleCoreRoleMemberSet"
 	EventTypeCircleCoreRoleMemberUnset EventType = "CircleCoreRoleMemberUnset"
 
-	// Member Root Aggregate
+	// MemberChange Aggregate
+	EventTypeMemberChangeCreateRequested      EventType = "MemberChangeCreateRequested"
+	EventTypeMemberChangeUpdateRequested      EventType = "MemberChangeUpdateRequested"
+	EventTypeMemberChangeSetMatchUIDRequested EventType = "MemberChangeSetMatchUIDRequested"
+	EventTypeMemberChangeCompleted            EventType = "MemberChangeCompleted"
+
+	// Member Aggregate
 	EventTypeMemberCreated     EventType = "MemberCreated"
 	EventTypeMemberUpdated     EventType = "MemberUpdated"
 	EventTypeMemberDeleted     EventType = "MemberDeleted"
@@ -171,11 +185,20 @@ const (
 	EventTypeMemberAvatarSet   EventType = "MemberAvatarSet"
 	EventTypeMemberMatchUIDSet EventType = "MemberMatchUIDSet"
 
-	// Tension Root Aggregate
+	// Tension Aggregate
 	EventTypeTensionCreated     EventType = "TensionCreated"
 	EventTypeTensionUpdated     EventType = "TensionUpdated"
 	EventTypeTensionRoleChanged EventType = "TensionRoleChanged"
 	EventTypeTensionClosed      EventType = "TensionClosed"
+
+	EventTypeMemberRequestHandlerStateUpdated EventType = "MemberRequestHandlerStateUpdated"
+
+	// MemberRequest Saga
+	EventTypeMemberRequestSagaCompleted EventType = "MemberRequestSagaCompleted"
+
+	// UniqueValueRegistry Aggregate
+	EventTypeUniqueRegistryValueReserved EventType = "UniqueRegistryValueReserved"
+	EventTypeUniqueRegistryValueReleased EventType = "UniqueRegistryValueReleased"
 )
 
 func GetEventDataType(eventType EventType) interface{} {
@@ -229,6 +252,15 @@ func GetEventDataType(eventType EventType) interface{} {
 	case EventTypeCircleCoreRoleMemberUnset:
 		return &EventCircleCoreRoleMemberUnset{}
 
+	case EventTypeMemberChangeCreateRequested:
+		return &EventMemberChangeCreateRequested{}
+	case EventTypeMemberChangeUpdateRequested:
+		return &EventMemberChangeUpdateRequested{}
+	case EventTypeMemberChangeSetMatchUIDRequested:
+		return &EventMemberChangeSetMatchUIDRequested{}
+	case EventTypeMemberChangeCompleted:
+		return &EventMemberChangeCompleted{}
+
 	case EventTypeMemberCreated:
 		return &EventMemberCreated{}
 	case EventTypeMemberUpdated:
@@ -248,6 +280,18 @@ func GetEventDataType(eventType EventType) interface{} {
 		return &EventTensionRoleChanged{}
 	case EventTypeTensionClosed:
 		return &EventTensionClosed{}
+
+	case EventTypeMemberRequestHandlerStateUpdated:
+		return &EventMemberRequestHandlerStateUpdated{}
+
+	case EventTypeMemberRequestSagaCompleted:
+		return &EventMemberRequestSagaCompleted{}
+
+	case EventTypeUniqueRegistryValueReserved:
+		return &EventUniqueRegistryValueReserved{}
+	case EventTypeUniqueRegistryValueReleased:
+		return &EventUniqueRegistryValueReleased{}
+
 	default:
 		panic(fmt.Errorf("unknown event type: %q", eventType))
 	}
@@ -689,19 +733,111 @@ func (e *EventTensionClosed) EventType() EventType {
 	return EventTypeTensionClosed
 }
 
+type EventMemberChangeCreateRequested struct {
+	MemberID     util.ID
+	IsAdmin      bool
+	MatchUID     string
+	UserName     string
+	FullName     string
+	Email        string
+	PasswordHash string
+	Avatar       []byte
+}
+
+func NewEventMemberChangeCreateRequested(memberChangeID util.ID, member *models.Member, matchUID, passwordHash string, avatar []byte) *EventMemberChangeCreateRequested {
+	return &EventMemberChangeCreateRequested{
+		MemberID:     member.ID,
+		IsAdmin:      member.IsAdmin,
+		MatchUID:     matchUID,
+		UserName:     member.UserName,
+		FullName:     member.FullName,
+		Email:        member.Email,
+		PasswordHash: passwordHash,
+		Avatar:       avatar,
+	}
+}
+
+func (e *EventMemberChangeCreateRequested) EventType() EventType {
+	return EventTypeMemberChangeCreateRequested
+}
+
+type EventMemberChangeUpdateRequested struct {
+	MemberID util.ID
+	IsAdmin  bool
+	UserName string
+	FullName string
+	Email    string
+	Avatar   []byte
+
+	PrevUserName string
+	PrevEmail    string
+}
+
+func NewEventMemberChangeUpdateRequested(memberChangeID util.ID, member *models.Member, avatar []byte, prevUserName, prevEmail string) *EventMemberChangeUpdateRequested {
+	return &EventMemberChangeUpdateRequested{
+		MemberID:     member.ID,
+		IsAdmin:      member.IsAdmin,
+		UserName:     member.UserName,
+		FullName:     member.FullName,
+		Email:        member.Email,
+		Avatar:       avatar,
+		PrevUserName: prevUserName,
+		PrevEmail:    prevEmail,
+	}
+}
+
+func (e *EventMemberChangeUpdateRequested) EventType() EventType {
+	return EventTypeMemberChangeUpdateRequested
+}
+
+type EventMemberChangeSetMatchUIDRequested struct {
+	MemberID util.ID
+	MatchUID string
+}
+
+func NewEventMemberChangeSetMatchUIDRequested(memberChangeID util.ID, memberID util.ID, matchUID string) *EventMemberChangeSetMatchUIDRequested {
+	return &EventMemberChangeSetMatchUIDRequested{
+		MemberID: memberID,
+		MatchUID: matchUID,
+	}
+}
+
+func (e *EventMemberChangeSetMatchUIDRequested) EventType() EventType {
+	return EventTypeMemberChangeSetMatchUIDRequested
+}
+
+type EventMemberChangeCompleted struct {
+	Error  bool
+	Reason string
+}
+
+func NewEventMemberChangeCompleted(memberChangeID util.ID, err bool, reason string) *EventMemberChangeCompleted {
+	return &EventMemberChangeCompleted{
+		Error:  err,
+		Reason: reason,
+	}
+}
+
+func (e *EventMemberChangeCompleted) EventType() EventType {
+	return EventTypeMemberChangeCompleted
+}
+
 type EventMemberCreated struct {
 	IsAdmin  bool
 	UserName string
 	FullName string
 	Email    string
+
+	MemberChangeID util.ID
 }
 
-func NewEventMemberCreated(member *models.Member) *EventMemberCreated {
+func NewEventMemberCreated(member *models.Member, memberChangeID util.ID) *EventMemberCreated {
 	return &EventMemberCreated{
-		IsAdmin:  member.IsAdmin,
-		UserName: member.UserName,
-		FullName: member.FullName,
-		Email:    member.Email,
+		IsAdmin:        member.IsAdmin,
+		UserName:       member.UserName,
+		FullName:       member.FullName,
+		Email:          member.Email,
+		MemberChangeID: memberChangeID,
 	}
 }
 
@@ -714,14 +850,22 @@ type EventMemberUpdated struct {
 	UserName string
 	FullName string
 	Email    string
+
+	MemberChangeID util.ID
+
+	PrevUserName string
+	PrevEmail    string
 }
 
-func NewEventMemberUpdated(member *models.Member) *EventMemberUpdated {
+func NewEventMemberUpdated(member *models.Member, memberChangeID util.ID, prevUserName, prevEmail string) *EventMemberUpdated {
 	return &EventMemberUpdated{
-		IsAdmin:  member.IsAdmin,
-		UserName: member.UserName,
-		FullName: member.FullName,
-		Email:    member.Email,
+		IsAdmin:        member.IsAdmin,
+		UserName:       member.UserName,
+		FullName:       member.FullName,
+		Email:          member.Email,
+		MemberChangeID: memberChangeID,
+		PrevUserName:   prevUserName,
+		PrevEmail:      prevEmail,
 	}
 }
 
@@ -759,9 +903,13 @@ func (e *EventMemberAvatarSet) EventType() EventType {
 
 type EventMemberMatchUIDSet struct {
 	MatchUID string
+
+	MemberChangeID util.ID
+
+	PrevMatchUID string
 }
 
-func NewEventMemberMatchUIDSet(memberID util.ID, matchUID string) *EventMemberMatchUIDSet {
+func NewEventMemberMatchUIDSet(memberID util.ID, memberChangeID util.ID, matchUID, prevMatchUID string) *EventMemberMatchUIDSet {
 	return &EventMemberMatchUIDSet{
 		MatchUID: matchUID,
 	}
@@ -769,4 +917,66 @@ func NewEventMemberMatchUIDSet(memberID util.ID, matchUID string) *EventMemberMa
 
 func (e *EventMemberMatchUIDSet) EventType() EventType {
 	return EventTypeMemberMatchUIDSet
+}
+
+type EventMemberRequestHandlerStateUpdated struct {
+	MemberChangeSequenceNumber int64
+	MemberSequenceNumber       int64
+}
+
+func NewEventMemberRequestHandlerStateUpdated(memberChangeSequenceNumber, memberSequenceNumber int64) *EventMemberRequestHandlerStateUpdated {
+	return &EventMemberRequestHandlerStateUpdated{
+		MemberChangeSequenceNumber: memberChangeSequenceNumber,
+		MemberSequenceNumber:       memberSequenceNumber,
+	}
+}
+
+func (e *EventMemberRequestHandlerStateUpdated) EventType() EventType {
+	return EventTypeMemberRequestHandlerStateUpdated
+}
+
+type EventMemberRequestSagaCompleted struct{}
+
+func NewEventMemberRequestSagaCompleted(sagaID string) *EventMemberRequestSagaCompleted {
+	return &EventMemberRequestSagaCompleted{}
+}
+
+func (e *EventMemberRequestSagaCompleted) EventType() EventType {
+	return EventTypeMemberRequestSagaCompleted
+}
+
+type EventUniqueRegistryValueReserved struct {
+	ID        util.ID
+	Value     string
+	RequestID util.ID
+}
+
+func NewEventUniqueRegistryValueReserved(registryID string, value string, id, requestID util.ID) *EventUniqueRegistryValueReserved {
+	return &EventUniqueRegistryValueReserved{
+		Value:     value,
+		ID:        id,
+		RequestID: requestID,
+	}
+}
+
+func (e *EventUniqueRegistryValueReserved) EventType() EventType {
+	return EventTypeUniqueRegistryValueReserved
+}
+
+type EventUniqueRegistryValueReleased struct {
+	ID        util.ID
+	Value     string
+	RequestID util.ID
+}
+
+func NewEventUniqueRegistryValueReleased(registryID string, value string, id, requestID util.ID) *EventUniqueRegistryValueReleased {
+	return &EventUniqueRegistryValueReleased{
+		Value:     value,
+		ID:        id,
+		RequestID: requestID,
+	}
+}
+
+func (e *EventUniqueRegistryValueReleased) EventType() EventType {
+	return EventTypeUniqueRegistryValueReleased
 }

--- a/eventstore/migration.go
+++ b/eventstore/migration.go
@@ -1,0 +1,23 @@
+package eventstore
+
+import (
+	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/sorintlab/sircles/db"
+)
+
+var Migrations = []db.Migration{
+	{
+		Stmts: []string{
+			`--POSTGRES
+             create table event (id uuid not null, sequencenumber bigserial, eventtype varchar not null, category varchar not null, streamid varchar not null, timestamp timestamptz not null, version bigint not null, data bytea, metadata bytea, PRIMARY KEY (sequencenumber), UNIQUE (category, streamid, version))`,
+			`--SQLITE3
+             create table event (id uuid not null, sequencenumber INTEGER PRIMARY KEY AUTOINCREMENT, eventtype varchar not null, category varchar not null, streamid varchar not null, timestamp timestamptz not null, version bigint not null, data bytea, metadata bytea, UNIQUE (category, streamid, version))`,
+			"create index event_streamid on event(streamid, version)",
+			"create index event_category on event(category)",
+
+			// stores the latest version for every stream
+			"create table streamversion (streamid varchar not null, category varchar not null, version bigint not null, PRIMARY KEY(streamid))",
+		},
+	},
+}

--- a/examples/dockerdemo/config.yaml
+++ b/examples/dockerdemo/config.yaml
@@ -3,11 +3,17 @@
 web:
   http: ':8080'
 
-db:
+readdb:
   # the database type (postgres or sqlite3), use postgres for production and
   # sqlite only for test
   type: 'sqlite3'
-  connString: '/sircles.db'
+  connString: '/readdb.db'
+
+eventStore:
+  type: 'sql'
+  db:
+    type: 'sqlite3'
+    connString: '/eventstore.db'
 
 # how the jwt token issued on login should be signed, preferred
 tokenSigning:
@@ -24,5 +30,5 @@ authentication:
 
 # type can be: local, ldap, oidc
   type: local
-    # the user should provided the email instead of the username for authentication
+    # the user should provide the email instead of the username for authentication
     #useEmail: true

--- a/readdb/migration.go
+++ b/readdb/migration.go
@@ -1,0 +1,106 @@
+package readdb
+
+import (
+	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/sorintlab/sircles/db"
+)
+
+var Migrations = []db.Migration{
+	{
+		Stmts: []string{
+			// processed events sequencenumbers
+			"create table sequencenumber (sequencenumber bigint, PRIMARY KEY(sequencenumber))",
+
+			// timeline
+			// we can end with different "events" happening at the same time
+			// (with millisecond precision for postgres), so timestamp cannot be
+			// unique.
+			"create table timeline (timestamp timestamptz not null, groupid uuid not null, aggregatetype varchar not null, aggregateid varchar not null, PRIMARY KEY(groupid))",
+			"create index timeline_ts on timeline(timestamp)",
+			"create index timeline_aggregatetype on timeline(aggregatetype)",
+			"create index timeline_aggregateid on timeline(aggregateid)",
+
+			// role is a one to many relation with child roles so it could be represented
+			// in the child role with a parent id. But, since we are implementing a time
+			// based db, we save the "edges" in a relation table so we have to just
+			// insert a new edge instead of inserting a full copy of the new child role
+			// timeline
+			//
+			// depth is used to be able to return values sorted by depth in the tree
+			// without computing the depth everytime (slow)
+			"create table role (id uuid, start_tl bigint, end_tl bigint, roletype varchar not null, depth int not null, name varchar, purpose varchar, PRIMARY KEY (id, start_tl))",
+			"create unique index role_tl on role(id, start_tl, end_tl DESC)",
+
+			"create table domain (id uuid, start_tl bigint, end_tl bigint, description varchar, PRIMARY KEY (id, start_tl))",
+			"create unique index domain_tl on domain(id, start_tl, end_tl DESC)",
+
+			"create table accountability (id uuid, start_tl bigint, end_tl bigint, description varchar, PRIMARY KEY (id, start_tl))",
+			"create unique index accountability_tl on accountability(id, start_tl, end_tl DESC)",
+
+			"create table roleadditionalcontent (id uuid, start_tl bigint, end_tl bigint, content varchar, PRIMARY KEY (id, start_tl))",
+			"create unique index roleadditionalcontent_tl on accountability(id, start_tl, end_tl DESC)",
+
+			// member
+			"create table member (id uuid, start_tl bigint, end_tl bigint, isadmin bool, username varchar, fullname varchar, email varchar, PRIMARY KEY (id, start_tl))",
+			"create unique index member_tl on member(id, start_tl, end_tl DESC)",
+
+			// id is the memberid
+			"create table memberavatar (id uuid, start_tl bigint, end_tl bigint, image bytea, PRIMARY KEY (id, start_tl))",
+			"create unique index memberavatar_tl on memberavatar(id, start_tl, end_tl DESC)",
+
+			"create table tension (id uuid, start_tl bigint, end_tl bigint, title varchar, description varchar, closed bool, closereason varchar, PRIMARY KEY (id, start_tl))",
+			"create unique index tension_tl on tension(id, start_tl, end_tl DESC)",
+
+			// edges
+			"create table rolerole (start_tl bigint, end_tl bigint, x uuid, y uuid)", // x: parent role id, y: child role id
+			"create index rolerole_x_start_tl on rolerole(x, start_tl, end_tl DESC)",
+			"create index rolerole_y_start_tl on rolerole(y, start_tl, end_tl DESC)",
+
+			"create table roledomain (start_tl bigint, end_tl bigint, x uuid, y uuid)", // x: domain id, y: role id
+			"create index roledomain_x_start_tl on roledomain(x, start_tl, end_tl DESC)",
+			"create index roledomain_y_start_tl on roledomain(y, start_tl, end_tl DESC)",
+
+			"create table roleaccountability (start_tl bigint, end_tl bigint, x uuid, y uuid)", // x: accountability id, y: role id
+			"create index roleaccountability_x_start_tl on roleaccountability(x, start_tl, end_tl DESC)",
+			"create index roleaccountability_y_start_tl on roleaccountability(y, start_tl, end_tl DESC)",
+
+			"create table circledirectmember (start_tl bigint, end_tl bigint, x uuid, y uuid)", // x: member id, y: role id
+			"create index circledirectmember_x_start_tl on circledirectmember(x, start_tl, end_tl DESC)",
+			"create index circledirectmember_y_start_tl on circledirectmember(y, start_tl, end_tl DESC)",
+
+			"create table rolemember (start_tl bigint, end_tl bigint, x uuid, y uuid, focus varchar, nocoremember bool, electionexpiration timestamptz)", // x: member id, y: role id
+			"create index rolemember_x_start_tl on rolemember(x, start_tl, end_tl DESC)",
+			"create index rolemember_y_start_tl on rolemember(y, start_tl, end_tl DESC)",
+
+			"create table membertension (start_tl bigint, end_tl bigint, x uuid, y uuid)", // x: tension id, y: member id
+			"create index membertension_x_start_tl on membertension(x, start_tl, end_tl DESC)",
+			"create index membertension_y_start_tl on membertension(y, start_tl, end_tl DESC)",
+
+			"create table roletension (start_tl bigint, end_tl bigint, x uuid, y uuid)", // x: tension id, y: role id
+			"create index roletension_x_start_tl on roletension(x, start_tl, end_tl DESC)",
+			"create index roletension_y_start_tl on roletension(y, start_tl, end_tl DESC)",
+
+			// read side events splitted in commands, per role and per member
+			"create table commandevent (timeline bigint, id uuid, issuer uuid, commandtype varchar, data bytea)",
+			"create table roleevent (timeline bigint, id uuid, command uuid, cause uuid, eventtype varchar, roleid uuid, data bytea)",
+			"create table memberevent (timeline bigint, id uuid, command uuid, cause uuid, eventtype varchar, memberid uuid, data bytea)",
+
+			// auth
+
+			// local passwords
+			"create table password (memberid uuid, password varchar)",
+
+			// NOTE while uuid is the local member unique id we also have a
+			// matchuid, it's used when using a non local authentication to
+			// match a attribute/claim reported by the authenticator to a local
+			// member.
+			// This value could be left empty when manually creating a member
+			// and only using local auth. Instead it's required when using or
+			// migrating to an external authentication mechanism.
+			// It'll be automatically populated when using a memberprovider to
+			// automatically create/update members.
+			"create table membermatch (memberid uuid, matchuid varchar)",
+		},
+	},
+}

--- a/saga/memberrequestsaga.go
+++ b/saga/memberrequestsaga.go
@@ -1,0 +1,547 @@
+package saga
+
+import (
+	"fmt"
+
+	"github.com/sorintlab/sircles/aggregate"
+	"github.com/sorintlab/sircles/command/commands"
+	"github.com/sorintlab/sircles/common"
+	"github.com/sorintlab/sircles/eventstore"
+	slog "github.com/sorintlab/sircles/log"
+	"github.com/sorintlab/sircles/util"
+)
+
+var log = slog.S()
+
+type MemberRequestSagaRepository struct {
+	es           *eventstore.EventStore
+	uidGenerator common.UIDGenerator
+}
+
+func NewMemberRequestSagaRepository(es *eventstore.EventStore, uidGenerator common.UIDGenerator) *MemberRequestSagaRepository {
+	return &MemberRequestSagaRepository{es: es, uidGenerator: uidGenerator}
+}
+
+func (r *MemberRequestSagaRepository) Load(id string) (*MemberRequestSaga, error) {
+	log.Debugf("Load id: %s", id)
+	s, err := NewMemberRequestSaga(r.es, r.uidGenerator, id)
+	if err != nil {
+		return nil, err
+	}
+
+	var v int64 = 0
+	for {
+		events, err := r.es.GetEvents(id, v, 100)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(events) == 0 {
+			break
+		}
+
+		v = events[len(events)-1].Version + 1
+
+		for _, e := range events {
+			log.Debugf("e: %v", e)
+			if err := s.ApplyEvent(e); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return s, nil
+}
+
+type MemberRequestSaga struct {
+	id      string
+	version int64
+
+	completed bool
+
+	es           *eventstore.EventStore
+	uidGenerator common.UIDGenerator
+}
+
+func NewMemberRequestSaga(es *eventstore.EventStore, uidGenerator common.UIDGenerator, id string) (*MemberRequestSaga, error) {
+	return &MemberRequestSaga{
+		id:           id,
+		es:           es,
+		uidGenerator: uidGenerator,
+	}, nil
+}
+
+func (s *MemberRequestSaga) Version() int64 {
+	return s.version
+}
+
+func (s *MemberRequestSaga) HandleCommand(command *commands.Command) ([]eventstore.Event, error) {
+	log.Debugf("saga HandleCommand: %#+v", command)
+	var events []eventstore.Event
+	var err error
+	switch command.CommandType {
+
+	default:
+		err = fmt.Errorf("unhandled command: %#v", command)
+	}
+
+	return events, err
+}
+
+func (s *MemberRequestSaga) HandleEvent(event *eventstore.StoredEvent) ([]eventstore.Event, error) {
+	log.Debugf("event: %v", event)
+
+	// if the saga is already completed ignore events
+	if s.completed {
+		return nil, nil
+	}
+
+	data, err := event.UnmarshalData()
+	if err != nil {
+		return nil, err
+	}
+	metaData, err := event.UnmarshalMetaData()
+	if err != nil {
+		return nil, err
+	}
+
+	// the cause of future commands is this event
+	causationID := event.ID
+	correlationID := *metaData.CorrelationID
+
+	switch event.EventType {
+	case eventstore.EventTypeMemberChangeCreateRequested:
+		data := data.(*eventstore.EventMemberChangeCreateRequested)
+		memberChangeID, err := util.IDFromString(event.StreamID)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := s.reserveUserName(correlationID, causationID, data.UserName, data.MemberID, memberChangeID); err != nil {
+			// If the registry returned an error assume it's an already reserved
+			// error
+			log.Error(err)
+			if err := s.completeMemberChange(correlationID, causationID, memberChangeID, fmt.Sprintf("username %q already reserved", data.UserName)); err != nil {
+				return nil, err
+
+			}
+			return nil, nil
+		}
+
+		if err := s.reserveEmail(correlationID, causationID, data.Email, data.MemberID, memberChangeID); err != nil {
+			// If the registry returned an error assume it's an already reserved
+			// error
+			log.Error(err)
+
+			if err := s.releaseUserName(correlationID, causationID, data.UserName, data.MemberID, memberChangeID); err != nil {
+				return nil, err
+			}
+
+			if err := s.completeMemberChange(correlationID, causationID, memberChangeID, fmt.Sprintf("email %q already reserved", data.Email)); err != nil {
+				return nil, err
+			}
+
+			return nil, nil
+		}
+
+		if data.MatchUID != "" {
+			if err := s.reserveMatchUID(correlationID, causationID, data.MatchUID, data.MemberID, memberChangeID); err != nil {
+				// If the registry returned an error assume it's an already reserved
+				// error
+				log.Error(err)
+
+				if err := s.releaseUserName(correlationID, causationID, data.UserName, data.MemberID, memberChangeID); err != nil {
+					return nil, err
+				}
+
+				if err := s.releaseEmail(correlationID, causationID, data.Email, data.MemberID, memberChangeID); err != nil {
+					return nil, err
+				}
+
+				if err := s.completeMemberChange(correlationID, causationID, memberChangeID, fmt.Sprintf("matchUID %q already reserved", data.MatchUID)); err != nil {
+					return nil, err
+				}
+
+				return nil, nil
+			}
+		}
+
+		mr := aggregate.NewMemberRepository(s.es, s.uidGenerator)
+		m, err := mr.Load(data.MemberID)
+		if err != nil {
+			return nil, err
+		}
+
+		log.Debugf("creating memberID %s", data.MemberID)
+		command := commands.NewCommand(commands.CommandTypeCreateMember, correlationID, causationID, util.NilID, &commands.CreateMember{
+			IsAdmin:        data.IsAdmin,
+			MatchUID:       data.MatchUID,
+			UserName:       data.UserName,
+			FullName:       data.FullName,
+			Email:          data.Email,
+			PasswordHash:   data.PasswordHash,
+			Avatar:         data.Avatar,
+			MemberChangeID: memberChangeID,
+		})
+
+		if _, _, err := aggregate.ExecCommand(command, m, s.es, s.uidGenerator); err != nil {
+			return nil, err
+		}
+
+	case eventstore.EventTypeMemberChangeUpdateRequested:
+		data := data.(*eventstore.EventMemberChangeUpdateRequested)
+		memberChangeID, err := util.IDFromString(event.StreamID)
+		if err != nil {
+			return nil, err
+		}
+
+		// we require the previous but eventually consistent username and email
+		// to know if we have to release them on failures in successive steps or
+		// after retrying handling the whole event
+		// Since the previous values are provided by the command service and
+		// read on the readdb, they can be older, so the member aggregate
+		// upgrade command will check them and return error if they have changed
+
+		userNameChanged := data.PrevUserName != data.UserName
+		emailChanged := data.PrevEmail != data.Email
+
+		if userNameChanged {
+			if err := s.reserveUserName(correlationID, causationID, data.UserName, data.MemberID, memberChangeID); err != nil {
+				// If the registry returned an error assume it's an already reserved
+				// error
+				log.Error(err)
+				if err := s.completeMemberChange(correlationID, causationID, memberChangeID, fmt.Sprintf("username %q already reserved", data.UserName)); err != nil {
+					return nil, err
+				}
+
+				return nil, nil
+			}
+		}
+
+		if emailChanged {
+			if err := s.reserveEmail(correlationID, causationID, data.Email, data.MemberID, memberChangeID); err != nil {
+				// If the registry returned an error assume it's an already reserved
+				// error
+				log.Error(err)
+
+				if userNameChanged {
+					if err := s.releaseUserName(correlationID, causationID, data.UserName, data.MemberID, memberChangeID); err != nil {
+						return nil, err
+					}
+				}
+
+				if err := s.completeMemberChange(correlationID, causationID, memberChangeID, fmt.Sprintf("email %q already reserved", data.Email)); err != nil {
+					return nil, err
+				}
+
+				return nil, nil
+			}
+		}
+
+		mr := aggregate.NewMemberRepository(s.es, s.uidGenerator)
+		m, err := mr.Load(data.MemberID)
+		if err != nil {
+			return nil, err
+		}
+
+		log.Debugf("updating memberID %s", data.MemberID)
+		command := commands.NewCommand(commands.CommandTypeUpdateMember, correlationID, causationID, util.NilID, &commands.UpdateMember{
+			IsAdmin:        data.IsAdmin,
+			UserName:       data.UserName,
+			FullName:       data.FullName,
+			Email:          data.Email,
+			Avatar:         data.Avatar,
+			MemberChangeID: memberChangeID,
+			PrevUserName:   data.PrevUserName,
+			PrevEmail:      data.PrevEmail,
+		})
+
+		_, _, err = aggregate.ExecCommand(command, m, s.es, s.uidGenerator)
+		if _, ok := err.(aggregate.HandleCommandError); ok {
+			// Rollback reservations if the member update command returned an error
+			log.Error(err)
+
+			if userNameChanged {
+				if err := s.releaseUserName(correlationID, causationID, data.UserName, data.MemberID, memberChangeID); err != nil {
+					return nil, err
+				}
+			}
+
+			if emailChanged {
+				if err := s.releaseEmail(correlationID, causationID, data.Email, data.MemberID, memberChangeID); err != nil {
+					return nil, err
+				}
+
+			}
+
+			if err := s.completeMemberChange(correlationID, causationID, memberChangeID, fmt.Sprintf("error updating member: %v, err")); err != nil {
+				return nil, err
+			}
+			return nil, err
+		}
+
+	case eventstore.EventTypeMemberChangeSetMatchUIDRequested:
+		data := data.(*eventstore.EventMemberChangeSetMatchUIDRequested)
+		memberChangeID, err := util.IDFromString(event.StreamID)
+		if err != nil {
+			return nil, err
+		}
+
+		if data.MatchUID != "" {
+			if err := s.reserveMatchUID(correlationID, causationID, data.MatchUID, data.MemberID, memberChangeID); err != nil {
+				// If the registry returned an error assume it's an already reserved
+				// error
+				log.Error(err)
+
+				if err := s.completeMemberChange(correlationID, causationID, memberChangeID, fmt.Sprintf("matchUID %q already reserved", data.MatchUID)); err != nil {
+					return nil, err
+				}
+
+				return nil, nil
+			}
+		}
+
+		mr := aggregate.NewMemberRepository(s.es, s.uidGenerator)
+		m, err := mr.Load(data.MemberID)
+		if err != nil {
+			return nil, err
+		}
+
+		log.Debugf("updating member %s matchUID", data.MemberID)
+		command := commands.NewCommand(commands.CommandTypeSetMemberMatchUID, correlationID, causationID, util.NilID, &commands.SetMemberMatchUID{
+			MatchUID:       data.MatchUID,
+			MemberChangeID: memberChangeID,
+		})
+
+		if _, _, err := aggregate.ExecCommand(command, m, s.es, s.uidGenerator); err != nil {
+			return nil, err
+		}
+
+	case eventstore.EventTypeMemberCreated:
+		data := data.(*eventstore.EventMemberCreated)
+
+		if err := s.completeMemberChange(correlationID, causationID, data.MemberChangeID, ""); err != nil {
+			return nil, err
+		}
+
+	case eventstore.EventTypeMemberUpdated:
+		data := data.(*eventstore.EventMemberUpdated)
+		memberID, err := util.IDFromString(event.StreamID)
+		if err != nil {
+			return nil, err
+		}
+
+		userNameChanged := data.PrevUserName != data.UserName
+		emailChanged := data.PrevEmail != data.Email
+
+		if userNameChanged {
+			if err := s.releaseUserName(correlationID, causationID, data.PrevUserName, memberID, data.MemberChangeID); err != nil {
+				return nil, err
+			}
+		}
+
+		if emailChanged {
+			if err := s.releaseEmail(correlationID, causationID, data.PrevEmail, memberID, data.MemberChangeID); err != nil {
+				return nil, err
+			}
+		}
+
+		if err := s.completeMemberChange(correlationID, causationID, data.MemberChangeID, ""); err != nil {
+			return nil, err
+		}
+
+	case eventstore.EventTypeMemberMatchUIDSet:
+		data := data.(*eventstore.EventMemberMatchUIDSet)
+		memberID, err := util.IDFromString(event.StreamID)
+		if err != nil {
+			return nil, err
+		}
+
+		if data.PrevMatchUID != "" {
+			if err := s.releaseMatchUID(correlationID, causationID, data.PrevMatchUID, memberID, data.MemberChangeID); err != nil {
+				return nil, err
+			}
+		}
+
+		if err := s.completeMemberChange(correlationID, causationID, data.MemberChangeID, ""); err != nil {
+			return nil, err
+		}
+
+	case eventstore.EventTypeMemberChangeCompleted:
+		events := []eventstore.Event{}
+		events = append(events, eventstore.NewEventMemberRequestSagaCompleted(s.id))
+		return events, nil
+
+	default:
+		return nil, fmt.Errorf("unhandled event: %#v", event)
+	}
+
+	return nil, nil
+}
+
+func (s *MemberRequestSaga) ApplyEvent(event *eventstore.StoredEvent) error {
+	log.Debugf("event: %v", event)
+
+	s.version = event.Version
+
+	switch event.EventType {
+	case eventstore.EventTypeMemberRequestSagaCompleted:
+		s.completed = true
+	}
+
+	return nil
+}
+
+func (s *MemberRequestSaga) reserveUserName(correlationID, causationID util.ID, userName string, memberID, requestID util.ID) error {
+	ur := aggregate.NewUniqueValueRegistryRepository(s.es, s.uidGenerator)
+	u, err := ur.Load(userNameRegistry(userName))
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("reserving userName %s, memberID %s", userName, memberID)
+	command := commands.NewCommand(commands.CommandTypeReserveValue, correlationID, causationID, util.NilID, &commands.ReserveValue{
+		Value:     userName,
+		ID:        memberID,
+		RequestID: requestID,
+	})
+
+	if _, _, err := aggregate.ExecCommand(command, u, s.es, s.uidGenerator); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *MemberRequestSaga) reserveEmail(correlationID, causationID util.ID, email string, memberID, requestID util.ID) error {
+	ur := aggregate.NewUniqueValueRegistryRepository(s.es, s.uidGenerator)
+	u, err := ur.Load(emailRegistry(email))
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("reserving email %s, memberID %s", email, memberID)
+	command := commands.NewCommand(commands.CommandTypeReserveValue, correlationID, causationID, util.NilID, &commands.ReserveValue{
+		Value:     email,
+		ID:        memberID,
+		RequestID: requestID,
+	})
+
+	if _, _, err := aggregate.ExecCommand(command, u, s.es, s.uidGenerator); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *MemberRequestSaga) reserveMatchUID(correlationID, causationID util.ID, matchUID string, memberID, requestID util.ID) error {
+	ur := aggregate.NewUniqueValueRegistryRepository(s.es, s.uidGenerator)
+	u, err := ur.Load(matchUIDRegistry(matchUID))
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("reserving matchUID %s, memberID %s", matchUID, memberID)
+	command := commands.NewCommand(commands.CommandTypeReserveValue, correlationID, causationID, util.NilID, &commands.ReserveValue{
+		Value:     matchUID,
+		ID:        memberID,
+		RequestID: requestID,
+	})
+
+	if _, _, err := aggregate.ExecCommand(command, u, s.es, s.uidGenerator); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *MemberRequestSaga) releaseUserName(correlationID, causationID util.ID, userName string, memberID, requestID util.ID) error {
+	ur := aggregate.NewUniqueValueRegistryRepository(s.es, s.uidGenerator)
+	u, err := ur.Load(userNameRegistry(userName))
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("releasing userName %s, memberID %s", userName, memberID)
+	command := commands.NewCommand(commands.CommandTypeReleaseValue, correlationID, causationID, util.NilID, &commands.ReleaseValue{
+		Value:     userName,
+		ID:        memberID,
+		RequestID: requestID,
+	})
+
+	if _, _, err := aggregate.ExecCommand(command, u, s.es, s.uidGenerator); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *MemberRequestSaga) releaseEmail(correlationID, causationID util.ID, email string, memberID, requestID util.ID) error {
+	ur := aggregate.NewUniqueValueRegistryRepository(s.es, s.uidGenerator)
+	u, err := ur.Load(emailRegistry(email))
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("releasing email %s, memberID %s", email, memberID)
+	command := commands.NewCommand(commands.CommandTypeReleaseValue, correlationID, causationID, util.NilID, &commands.ReleaseValue{
+		Value:     email,
+		ID:        memberID,
+		RequestID: requestID,
+	})
+
+	if _, _, err := aggregate.ExecCommand(command, u, s.es, s.uidGenerator); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *MemberRequestSaga) releaseMatchUID(correlationID, causationID util.ID, matchUID string, memberID, requestID util.ID) error {
+	ur := aggregate.NewUniqueValueRegistryRepository(s.es, s.uidGenerator)
+	u, err := ur.Load(matchUIDRegistry(matchUID))
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("releasing matchUID %s, memberID %s", matchUID, memberID)
+	command := commands.NewCommand(commands.CommandTypeReleaseValue, correlationID, causationID, util.NilID, &commands.ReleaseValue{
+		Value:     matchUID,
+		ID:        memberID,
+		RequestID: requestID,
+	})
+
+	if _, _, err := aggregate.ExecCommand(command, u, s.es, s.uidGenerator); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *MemberRequestSaga) completeMemberChange(correlationID, causationID util.ID, memberChangeID util.ID, errReason string) error {
+	mcr := aggregate.NewMemberChangeRepository(s.es, s.uidGenerator)
+	mc, err := mcr.Load(memberChangeID)
+	if err != nil {
+		return err
+	}
+
+	var command *commands.Command
+	if errReason == "" {
+		log.Debugf("completing memberChangeID %s", memberChangeID)
+		command = commands.NewCommand(commands.CommandTypeCompleteRequest, correlationID, causationID, util.NilID, &commands.CompleteRequest{})
+	} else {
+		log.Debugf("completing memberChangeID %s with error", memberChangeID)
+		command = commands.NewCommand(commands.CommandTypeCompleteRequest, correlationID, causationID, util.NilID, &commands.CompleteRequest{Error: true, Reason: errReason})
+	}
+
+	if _, _, err := aggregate.ExecCommand(command, mc, s.es, s.uidGenerator); err != nil {
+		return err
+	}
+	return nil
+}
+
+func userNameRegistry(userName string) string {
+	return fmt.Sprintf("username-%s", userName)
+}
+
+func emailRegistry(userName string) string {
+	return fmt.Sprintf("email-%s", userName)
+}
+
+func matchUIDRegistry(userName string) string {
+	return fmt.Sprintf("matchuid-%s", userName)
+}

--- a/scripts/git-version.sh
+++ b/scripts/git-version.sh
@@ -1,5 +1,4 @@
 #!/bin/sh -e
-# Since this script will be run in a rkt container, use "/bin/sh" instead of "/bin/bash"
 
 # parse the current git commit hash
 COMMIT=`git rev-parse HEAD`

--- a/util/id.go
+++ b/util/id.go
@@ -23,6 +23,11 @@ func IDFromString(us string) (ID, error) {
 	return ID{UUID: u}, nil
 }
 
+func IDFromStringOrNil(us string) ID {
+	u := uuid.FromStringOrNil(us)
+	return ID{UUID: u}
+}
+
 type IDs []ID
 
 func (p IDs) Len() int           { return len(p) }


### PR DESCRIPTION
Use the aggregates, eventhandlers and saga implemented in the first patches.

The eventstore and the readdb are completely decoupled.
The readdb is an eventhandler that will listen on new events and apply them.

Every write to the eventstore is a single transaction.

Change the postgres default transaction isolation level from serializable to
repeatable read since we are able to achieve more concurrency maintaing
consistency without the protection of the serializable level.

The command services, after data validation, executes a command on the related
aggregate. Every command services method operates on only one aggregates.

To keep synchronous client response, the graphql api will wait for the generated
events to be applied in the readdb.

If a command (like createMember) will trigger a saga, we'll wait for the saga to
be completed.

More docs/blogs will come to explain all the choices and how they works.

