### PR TITLE
eventstore: various improvements and simplifications

### DIFF
--- a/cmd/sircles/restore.go
+++ b/cmd/sircles/restore.go
@@ -93,9 +93,9 @@ func restore(cmd *cobra.Command, args []string) error {
 
 	dec := json.NewDecoder(f)
 
-	events := eventstore.Events{}
+	events := []*eventstore.StoredEvent{}
 	for {
-		var event *eventstore.Event
+		var event *eventstore.StoredEvent
 		err := dec.Decode(&event)
 		if err != nil {
 			log.Fatal(err)
@@ -108,7 +108,7 @@ func restore(cmd *cobra.Command, args []string) error {
 			if err := applyEvents(db, events); err != nil {
 				return err
 			}
-			events = eventstore.Events{}
+			events = []*eventstore.StoredEvent{}
 		}
 		if !hasMore {
 			break
@@ -118,7 +118,7 @@ func restore(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func applyEvents(db *db.DB, events eventstore.Events) error {
+func applyEvents(db *db.DB, events []*eventstore.StoredEvent) error {
 	tx, err := db.NewTx()
 	if err != nil {
 		return err

--- a/command/commands/commands.go
+++ b/command/commands/commands.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/sorintlab/sircles/change"
 	"github.com/sorintlab/sircles/models"
 	"github.com/sorintlab/sircles/util"
@@ -53,27 +54,30 @@ const (
 )
 
 type Command struct {
+	ID            util.ID
 	CommandType   CommandType
-	CausationID   util.ID
 	CorrelationID util.ID
+	CausationID   util.ID
 	IssuerID      util.ID
 	Data          interface{}
 }
 
 type CommandRaw struct {
+	ID            util.ID
 	CommandType   CommandType
-	CausationID   util.ID
 	CorrelationID util.ID
+	CausationID   util.ID
 	IssuerID      util.ID
 	Data          json.RawMessage
 }
 
-func NewCommand(commandType CommandType, causationID, correlationID, issuerID util.ID, commandData interface{}) *Command {
+func NewCommand(commandType CommandType, correlationID, causationID, issuerID util.ID, commandData interface{}) *Command {
 	// TODO(sgotti) detect commandType from commandData real type
 	return &Command{
+		ID:            util.NewFromUUID(uuid.NewV4()),
 		CommandType:   commandType,
-		CausationID:   causationID,
 		CorrelationID: correlationID,
+		CausationID:   causationID,
 		IssuerID:      issuerID,
 		Data:          commandData,
 	}
@@ -91,6 +95,7 @@ func (c *Command) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	c.ID = cr.ID
 	c.CommandType = cr.CommandType
 	c.CausationID = cr.CausationID
 	c.CorrelationID = cr.CorrelationID

--- a/db/migration.go
+++ b/db/migration.go
@@ -99,9 +99,9 @@ var migrations = []migration{
 		stmts: []string{
 			// === EventStore ===
 			`--POSTGRES
-             create table event (id uuid not null, sequencenumber bigserial, eventtype varchar not null, aggregatetype varchar not null, aggregateid varchar not null, timestamp timestamptz not null, version bigint not null, correlationid uuid, causationid uuid, groupid uuid, data bytea, PRIMARY KEY (sequencenumber), UNIQUE (aggregatetype, aggregateid, version))`,
+             create table event (id uuid not null, sequencenumber bigserial, eventtype varchar not null, aggregatetype varchar not null, aggregateid varchar not null, timestamp timestamptz not null, version bigint not null, data bytea, metadata bytea, PRIMARY KEY (sequencenumber), UNIQUE (aggregatetype, aggregateid, version))`,
 			`--SQLITE3
-             create table event (id uuid not null, sequencenumber INTEGER PRIMARY KEY AUTOINCREMENT, eventtype varchar not null, aggregatetype varchar not null, aggregateid varchar not null, timestamp timestamptz not null, version bigint not null, correlationid uuid, causationid uuid, groupid uuid, data bytea, UNIQUE (aggregatetype, aggregateid, version))`,
+             create table event (id uuid not null, sequencenumber INTEGER PRIMARY KEY AUTOINCREMENT, eventtype varchar not null, aggregatetype varchar not null, aggregateid varchar not null, timestamp timestamptz not null, version bigint not null, data bytea, metadata bytea, UNIQUE (aggregatetype, aggregateid, version))`,
 			"create index event_aggregateid_version on event(aggregateid, version)",
 			"create index event_aggregatetype on event(aggregatetype)",
 

--- a/search/search.go
+++ b/search/search.go
@@ -222,26 +222,31 @@ func (s *SearchEngine) delete(ids []util.ID) error {
 	return nil
 }
 
-func (s *SearchEngine) HandlEvent(event *eventstore.Event) error {
+func (s *SearchEngine) HandlEvent(event *eventstore.StoredEvent) error {
 	reindexRoles := []util.ID{}
 	deleteRoles := []util.ID{}
 	reindexMembers := []util.ID{}
 	deleteMembers := []util.ID{}
+
+	data, err := event.UnmarshalData()
+	if err != nil {
+		return err
+	}
 
 	switch event.EventType {
 	case eventstore.EventTypeCommandExecuted:
 	case eventstore.EventTypeCommandExecutionFinished:
 
 	case eventstore.EventTypeRoleCreated:
-		data := event.Data.(*eventstore.EventRoleCreated)
+		data := data.(*eventstore.EventRoleCreated)
 		reindexRoles = append(reindexRoles, data.RoleID)
 
 	case eventstore.EventTypeRoleDeleted:
-		data := event.Data.(*eventstore.EventRoleDeleted)
+		data := data.(*eventstore.EventRoleDeleted)
 		deleteRoles = append(deleteRoles, data.RoleID)
 
 	case eventstore.EventTypeRoleUpdated:
-		data := event.Data.(*eventstore.EventRoleUpdated)
+		data := data.(*eventstore.EventRoleUpdated)
 		reindexRoles = append(reindexRoles, data.RoleID)
 
 	case eventstore.EventTypeRoleDomainCreated:
@@ -261,39 +266,39 @@ func (s *SearchEngine) HandlEvent(event *eventstore.Event) error {
 	case eventstore.EventTypeRoleChangedParent:
 
 	case eventstore.EventTypeRoleMemberAdded:
-		data := event.Data.(*eventstore.EventRoleMemberAdded)
+		data := data.(*eventstore.EventRoleMemberAdded)
 		reindexMembers = append(reindexMembers, data.MemberID)
 
 	case eventstore.EventTypeRoleMemberUpdated:
-		data := event.Data.(*eventstore.EventRoleMemberUpdated)
+		data := data.(*eventstore.EventRoleMemberUpdated)
 		reindexMembers = append(reindexMembers, data.MemberID)
 
 	case eventstore.EventTypeRoleMemberRemoved:
-		data := event.Data.(*eventstore.EventRoleMemberRemoved)
+		data := data.(*eventstore.EventRoleMemberRemoved)
 		reindexMembers = append(reindexMembers, data.MemberID)
 
 	case eventstore.EventTypeCircleDirectMemberAdded:
-		data := event.Data.(*eventstore.EventCircleDirectMemberAdded)
+		data := data.(*eventstore.EventCircleDirectMemberAdded)
 		reindexMembers = append(reindexMembers, data.MemberID)
 
 	case eventstore.EventTypeCircleDirectMemberRemoved:
-		data := event.Data.(*eventstore.EventCircleDirectMemberRemoved)
+		data := data.(*eventstore.EventCircleDirectMemberRemoved)
 		reindexMembers = append(reindexMembers, data.MemberID)
 
 	case eventstore.EventTypeCircleLeadLinkMemberSet:
-		data := event.Data.(*eventstore.EventCircleLeadLinkMemberSet)
+		data := data.(*eventstore.EventCircleLeadLinkMemberSet)
 		reindexMembers = append(reindexMembers, data.MemberID)
 
 	case eventstore.EventTypeCircleLeadLinkMemberUnset:
-		data := event.Data.(*eventstore.EventCircleLeadLinkMemberUnset)
+		data := data.(*eventstore.EventCircleLeadLinkMemberUnset)
 		reindexMembers = append(reindexMembers, data.MemberID)
 
 	case eventstore.EventTypeCircleCoreRoleMemberSet:
-		data := event.Data.(*eventstore.EventCircleCoreRoleMemberSet)
+		data := data.(*eventstore.EventCircleCoreRoleMemberSet)
 		reindexMembers = append(reindexMembers, data.MemberID)
 
 	case eventstore.EventTypeCircleCoreRoleMemberUnset:
-		data := event.Data.(*eventstore.EventCircleCoreRoleMemberUnset)
+		data := data.(*eventstore.EventCircleCoreRoleMemberUnset)
 		reindexMembers = append(reindexMembers, data.MemberID)
 
 	case eventstore.EventTypeTensionCreated:


### PR DESCRIPTION
* Split between the event generated and the event stored structures

* The correlationID, causationID, groupID are not part of the stored event but
are moved to the event metadata.

* The eventstore won't marshall/unmarshall the event data and metadata

* The generated event struct contains only the eventtype, the event data and the
event metadata

* The correlationID, causationID, groupID are the same for all the aggregate
events generated by that command invocation.