### PR TITLE
*: remove command events

### DIFF
--- a/api/graphql/schema_test.go
+++ b/api/graphql/schema_test.go
@@ -780,21 +780,21 @@ func TestTimeLines(t *testing.T) {
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMDk5ODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMDk5NjAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509030998000000000"
+							"id": "1509030996000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAwMzAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMDk5OTAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031003000000000"
+							"id": "1509030999000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAwODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAwMjAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031008000000000"
+							"id": "1509031002000000000"
 						}
 					}
 					],
@@ -820,7 +820,7 @@ func TestTimeLines(t *testing.T) {
 			Variables: `
 			{
 				"first": 4,
-				"after": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAwODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0="
+				"after": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAwMjAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0="
 			}
 			`,
 			ExpectedResult: `
@@ -828,27 +828,27 @@ func TestTimeLines(t *testing.T) {
 				"timeLines": {
 					"edges": [
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAxMzAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAwNTAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031013000000000"
+							"id": "1509031005000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAxODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAwODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031018000000000"
+							"id": "1509031008000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAyMzAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAxMTAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031023000000000"
+							"id": "1509031011000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAyODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAxNDAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031028000000000"
+							"id": "1509031014000000000"
 						}
 					}
 					],
@@ -874,7 +874,7 @@ func TestTimeLines(t *testing.T) {
 			Variables: `
 			{
 				"last": 4,
-				"before": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAwODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0="
+				"before": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAwMjAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0="
 			}
 			`,
 			ExpectedResult: `
@@ -882,15 +882,15 @@ func TestTimeLines(t *testing.T) {
 				"timeLines": {
 					"edges": [
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAwMzAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMDk5OTAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031003000000000"
+							"id": "1509030999000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMDk5ODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMDk5NjAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiIiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509030998000000000"
+							"id": "1509030996000000000"
 						}
 					},
 					{
@@ -938,21 +938,21 @@ func TestTimeLines(t *testing.T) {
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA0ODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAyNjAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031048000000000"
+							"id": "1509031026000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA1MTAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAyNzAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031051000000000"
+							"id": "1509031027000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA1NDAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAyODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031054000000000"
+							"id": "1509031028000000000"
 						}
 					}
 					],
@@ -978,7 +978,7 @@ func TestTimeLines(t *testing.T) {
 			Variables: `
 			{
 				"first": 4,
-				"after": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA1NDAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0="
+				"after": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAyODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0="
 			}
 			`,
 			ExpectedResult: `
@@ -986,27 +986,27 @@ func TestTimeLines(t *testing.T) {
 				"timeLines": {
 					"edges": [
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA1NzAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAyOTAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031057000000000"
+							"id": "1509031029000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA2MDAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAzMDAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031060000000000"
+							"id": "1509031030000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA4MzAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA1MTAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031083000000000"
+							"id": "1509031051000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA4NjAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA1MjAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031086000000000"
+							"id": "1509031052000000000"
 						}
 					}
 					],
@@ -1032,7 +1032,7 @@ func TestTimeLines(t *testing.T) {
 			Variables: `
 			{
 				"last": 4,
-				"before": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA1NDAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0="
+				"before": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAyODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0="
 			}
 			`,
 			ExpectedResult: `
@@ -1040,15 +1040,15 @@ func TestTimeLines(t *testing.T) {
 				"timeLines": {
 					"edges": [
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA1MTAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAyNzAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031051000000000"
+							"id": "1509031027000000000"
 						}
 					},
 					{
-						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTA0ODAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
+						"cursor": "eyJUaW1lTGluZUlEIjoiMTUwOTAzMTAyNjAwMDAwMDAwMCIsIkFnZ3JlZ2F0ZVR5cGUiOiJyb2xlc3RyZWUiLCJBZ2dyZWdhdGVJRCI6bnVsbH0=",
 						"timeLine": {
-							"id": "1509031048000000000"
+							"id": "1509031026000000000"
 						}
 					},
 					{

--- a/command/commands/commands.go
+++ b/command/commands/commands.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"encoding/json"
-	"fmt"
 	"time"
 
 	uuid "github.com/satori/go.uuid"
@@ -62,15 +60,6 @@ type Command struct {
 	Data          interface{}
 }
 
-type CommandRaw struct {
-	ID            util.ID
-	CommandType   CommandType
-	CorrelationID util.ID
-	CausationID   util.ID
-	IssuerID      util.ID
-	Data          json.RawMessage
-}
-
 func NewCommand(commandType CommandType, correlationID, causationID, issuerID util.ID, commandData interface{}) *Command {
 	// TODO(sgotti) detect commandType from commandData real type
 	return &Command{
@@ -80,89 +69,6 @@ func NewCommand(commandType CommandType, correlationID, causationID, issuerID ut
 		CausationID:   causationID,
 		IssuerID:      issuerID,
 		Data:          commandData,
-	}
-}
-
-func (c *Command) UnmarshalJSON(data []byte) error {
-	var cr CommandRaw
-
-	if err := json.Unmarshal(data, &cr); err != nil {
-		return err
-	}
-
-	d := GetDataType(cr.CommandType)
-	if err := json.Unmarshal(cr.Data, &d); err != nil {
-		return err
-	}
-
-	c.ID = cr.ID
-	c.CommandType = cr.CommandType
-	c.CausationID = cr.CausationID
-	c.CorrelationID = cr.CorrelationID
-	c.IssuerID = cr.IssuerID
-	c.Data = d
-
-	return nil
-}
-
-func GetDataType(commandType CommandType) interface{} {
-	switch commandType {
-	case CommandTypeSetupRootRole:
-		return &SetupRootRole{}
-	case CommandTypeUpdateRootRole:
-		return &UpdateRootRole{}
-
-	case CommandTypeCircleCreateChildRole:
-		return &CircleCreateChildRole{}
-	case CommandTypeCircleUpdateChildRole:
-		return &CircleUpdateChildRole{}
-	case CommandTypeCircleDeleteChildRole:
-		return &CircleDeleteChildRole{}
-
-	case CommandTypeSetRoleAdditionalContent:
-		return &SetRoleAdditionalContent{}
-
-	case CommandTypeCreateMember:
-		return &CreateMember{}
-	case CommandTypeUpdateMember:
-		return &UpdateMember{}
-	//case CommandTypeDeleteMember :
-	//	return &CommandDeleteMember{}
-	case CommandTypeSetMemberPassword:
-		return &SetMemberPassword{}
-	case CommandTypeSetMemberMatchUID:
-		return &SetMemberMatchUID{}
-
-	case CommandTypeCreateTension:
-		return &CreateTension{}
-	case CommandTypeUpdateTension:
-		return &UpdateTension{}
-	case CommandTypeCloseTension:
-		return &CloseTension{}
-
-	case CommandTypeCircleAddDirectMember:
-		return &CircleAddDirectMember{}
-	case CommandTypeCircleRemoveDirectMember:
-		return &CircleRemoveDirectMember{}
-
-	case CommandTypeCircleSetLeadLinkMember:
-		return &CircleSetLeadLinkMember{}
-	case CommandTypeCircleUnsetLeadLinkMember:
-		return &CircleUnsetLeadLinkMember{}
-
-	case CommandTypeCircleSetCoreRoleMember:
-		return &CircleSetCoreRoleMember{}
-	case CommandTypeCircleUnsetCoreRoleMember:
-		return &CircleUnsetCoreRoleMember{}
-
-	case CommandTypeRoleAddMember:
-		return &RoleAddMember{}
-	case CommandTypeRoleUpdateMember:
-		return &RoleUpdateMember{}
-	case CommandTypeRoleRemoveMember:
-		return &RoleRemoveMember{}
-	default:
-		panic(fmt.Errorf("unknown command type: %q", commandType))
 	}
 }
 

--- a/eventstore/eventstore_test.go
+++ b/eventstore/eventstore_test.go
@@ -13,10 +13,10 @@ import (
 func TestWriteEvents(t *testing.T) {
 	events := []*EventData{
 		&EventData{
-			EventType: EventTypeCommandExecuted,
+			EventType: EventTypeRoleCreated,
 		},
 		&EventData{
-			EventType: EventTypeRoleCreated,
+			EventType: EventTypeRoleUpdated,
 		},
 		&EventData{
 			EventType: EventTypeRoleMemberAdded,
@@ -106,13 +106,12 @@ func TestWriteEvents(t *testing.T) {
 }
 
 func TestRestoreEvents(t *testing.T) {
-
 	events1 := []*EventData{
 		&EventData{
-			EventType: EventTypeCommandExecuted,
+			EventType: EventTypeRoleCreated,
 		},
 		&EventData{
-			EventType: EventTypeRoleCreated,
+			EventType: EventTypeRoleUpdated,
 		},
 		&EventData{
 			EventType: EventTypeRoleMemberAdded,
@@ -121,10 +120,10 @@ func TestRestoreEvents(t *testing.T) {
 
 	events2 := []*EventData{
 		&EventData{
-			EventType: EventTypeCommandExecuted,
+			EventType: EventTypeRoleCreated,
 		},
 		&EventData{
-			EventType: EventTypeRoleCreated,
+			EventType: EventTypeRoleUpdated,
 		},
 		&EventData{
 			EventType: EventTypeRoleMemberAdded,

--- a/models/roleevent.go
+++ b/models/roleevent.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/sorintlab/sircles/util"
 )
 
@@ -29,10 +30,10 @@ func GetRoleEventDataType(eventType RoleEventType) interface{} {
 	}
 }
 
-func newRoleEvent(timeLineID util.TimeLineNumber, id, roleID util.ID, eventType RoleEventType, data interface{}) *RoleEvent {
+func newRoleEvent(timeLineID util.TimeLineNumber, roleID util.ID, eventType RoleEventType, data interface{}) *RoleEvent {
 	return &RoleEvent{
 		TimeLineID: timeLineID,
-		ID:         id,
+		ID:         util.NewFromUUID(uuid.NewV4()),
 		RoleID:     roleID,
 		EventType:  eventType,
 		Data:       data,
@@ -68,10 +69,9 @@ type RoleEventCircleChangesApplied struct {
 	RolesToCircle map[util.ID]util.ID
 }
 
-func NewRoleEventCircleChangesApplied(timeLineID util.TimeLineNumber, id, roleID, issuerID util.ID) *RoleEvent {
+func NewRoleEventCircleChangesApplied(timeLineID util.TimeLineNumber, roleID, issuerID util.ID) *RoleEvent {
 	return newRoleEvent(
 		timeLineID,
-		id,
 		roleID,
 		RoleEventTypeCircleChangesApplied,
 		&RoleEventCircleChangesApplied{

--- a/search/search.go
+++ b/search/search.go
@@ -234,9 +234,6 @@ func (s *SearchEngine) HandlEvent(event *eventstore.StoredEvent) error {
 	}
 
 	switch event.EventType {
-	case eventstore.EventTypeCommandExecuted:
-	case eventstore.EventTypeCommandExecutionFinished:
-
 	case eventstore.EventTypeRoleCreated:
 		data := data.(*eventstore.EventRoleCreated)
 		reindexRoles = append(reindexRoles, data.RoleID)


### PR DESCRIPTION
do not use events to save commands. They aren't an aggregate event.

In future add a way to log them for auditing and correlation with generated
events.

The command's IssuerID is moved to every event metadata as CommandIssuerID since
it's needed by the readdb.