### PR TITLE
Add listen notify package

### DIFF
--- a/listennotify/listennotify.go
+++ b/listennotify/listennotify.go
@@ -1,0 +1,39 @@
+package listennotify
+
+import "github.com/sorintlab/sircles/db"
+
+type Type int
+
+const (
+	Local Type = iota
+	Postgres
+)
+
+type Notification struct {
+	Channel string
+	Payload string
+}
+
+type Notifier interface {
+	Notify(channel string, payload string) error
+}
+
+type TxNotifier interface {
+	Notifier
+	BindTx(tx *db.Tx)
+}
+
+type NotifierFactory interface {
+	NewNotifier() Notifier
+}
+
+type Listener interface {
+	NotificationChannel() chan *Notification
+	Close() error
+	Listen(channel string) error
+	Ping() error
+}
+
+type ListenerFactory interface {
+	NewListener() Listener
+}

--- a/listennotify/local.go
+++ b/listennotify/local.go
@@ -1,0 +1,146 @@
+package listennotify
+
+import (
+	"sync"
+)
+
+type LocalListenNotify struct {
+	channels map[string][]chan *Notification
+
+	rwMutex sync.RWMutex
+}
+
+func (ln *LocalListenNotify) start(channel string, c chan *Notification) {
+	ln.rwMutex.Lock()
+	defer ln.rwMutex.Unlock()
+
+	ln.channels[channel] = append(ln.channels[channel], c)
+}
+
+func (ln *LocalListenNotify) stop(channel string, c chan *Notification) {
+	ln.rwMutex.Lock()
+	defer ln.rwMutex.Unlock()
+
+	newArray := make([]chan *Notification, 0)
+	outChans, ok := ln.channels[channel]
+	if !ok {
+		return
+	}
+	for _, ch := range outChans {
+		if ch != c {
+			newArray = append(newArray, ch)
+		}
+	}
+	ln.channels[channel] = newArray
+
+	return
+}
+
+func (ln *LocalListenNotify) stopAll(c chan *Notification) {
+	ln.rwMutex.Lock()
+	defer ln.rwMutex.Unlock()
+
+	for channel := range ln.channels {
+		newArray := make([]chan *Notification, 0)
+		outChans, ok := ln.channels[channel]
+		if !ok {
+			return
+		}
+		for _, ch := range outChans {
+			if ch != c {
+				newArray = append(newArray, ch)
+			}
+		}
+		ln.channels[channel] = newArray
+	}
+
+	return
+}
+
+func (ln *LocalListenNotify) notify(channel string, payload string) {
+	ln.rwMutex.RLock()
+	defer ln.rwMutex.RUnlock()
+
+	outChans, ok := ln.channels[channel]
+	if !ok {
+		return
+	}
+	for _, outputChan := range outChans {
+		outputChan <- &Notification{
+			Channel: channel,
+			Payload: payload,
+		}
+	}
+}
+
+func NewLocalListenNotify() *LocalListenNotify {
+	return &LocalListenNotify{
+		channels: make(map[string][]chan *Notification),
+	}
+}
+
+type LocalNotifier struct {
+	ln *LocalListenNotify
+}
+
+func (l *LocalNotifier) Notify(channel string, payload string) error {
+	l.ln.notify(channel, payload)
+	return nil
+}
+
+type LocalNotifierFactory struct {
+	ln *LocalListenNotify
+}
+
+func NewLocalNotifierFactory(ln *LocalListenNotify) *LocalNotifierFactory {
+	return &LocalNotifierFactory{ln: ln}
+}
+
+func (lnf *LocalNotifierFactory) NewNotifier() Notifier {
+	return &LocalNotifier{
+		ln: lnf.ln,
+	}
+}
+
+type LocalListener struct {
+	ln     *LocalListenNotify
+	notify chan *Notification
+	stop   chan struct{}
+}
+
+func (l *LocalListener) NotificationChannel() chan *Notification {
+	return l.notify
+}
+
+func (l *LocalListener) Listen(channel string) error {
+	l.ln.start(channel, l.notify)
+	return nil
+}
+
+func (l *LocalListener) Ping() error {
+	return nil
+}
+
+func (l *LocalListener) Close() error {
+	l.ln.stopAll(l.notify)
+	close(l.notify)
+	return nil
+}
+
+type LocalListenerFactory struct {
+	ln *LocalListenNotify
+}
+
+func NewLocalListenerFactory(ln *LocalListenNotify) *LocalListenerFactory {
+	return &LocalListenerFactory{ln: ln}
+}
+
+func (lnf *LocalListenerFactory) NewListener() Listener {
+	stop := make(chan struct{})
+	notify := make(chan *Notification, 1000)
+	return &LocalListener{
+		ln:     lnf.ln,
+		notify: notify,
+		stop:   stop,
+	}
+}

--- a/listennotify/postgres.go
+++ b/listennotify/postgres.go
@@ -1,0 +1,108 @@
+package listennotify
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/sorintlab/sircles/db"
+)
+
+type PGNotifier struct {
+	tx *db.Tx
+}
+
+func NewPGNotifier() *PGNotifier {
+	return &PGNotifier{}
+}
+
+func (l *PGNotifier) BindTx(tx *db.Tx) {
+	l.tx = tx
+}
+
+func (l *PGNotifier) Notify(channel string, payload string) error {
+	if l.tx == nil {
+		return errors.New("nil tx")
+	}
+	err := l.tx.Do(func(tx *db.WrappedTx) error {
+		_, err := tx.Exec(fmt.Sprintf("notify %s %s", channel, payload))
+		return err
+	})
+	return err
+}
+
+type PGNotifierFactory struct{}
+
+func NewPGNotifierFactory() *PGNotifierFactory {
+	return &PGNotifierFactory{}
+}
+
+func (lnf *PGNotifierFactory) NewNotifier() Notifier {
+	return NewPGNotifier()
+}
+
+type PGListener struct {
+	listener *pq.Listener
+	notify   chan *Notification
+	stop     chan struct{}
+}
+
+func NewPGListener(connString string) *PGListener {
+	minReconn := 10 * time.Second
+	maxReconn := time.Minute
+	listener := pq.NewListener(connString, minReconn, maxReconn, nil)
+	stop := make(chan struct{})
+	notify := make(chan *Notification)
+	l := &PGListener{listener: listener, notify: notify, stop: stop}
+
+	go func() {
+		for {
+			select {
+			case pn := <-l.listener.Notify:
+				if pn == nil {
+					continue
+				}
+				n := &Notification{
+					Channel: pn.Channel,
+					Payload: pn.Extra,
+				}
+				notify <- n
+
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	return l
+}
+
+func (l *PGListener) NotificationChannel() chan *Notification {
+	return l.notify
+}
+
+func (l *PGListener) Listen(channel string) error {
+	return l.listener.Listen(channel)
+}
+
+func (l *PGListener) Ping() error {
+	return l.listener.Ping()
+}
+
+func (l *PGListener) Close() error {
+	close(l.stop)
+	return l.listener.Close()
+}
+
+type PGListenerFactory struct {
+	connString string
+}
+
+func NewPGListenerFactory(connString string) *PGListenerFactory {
+	return &PGListenerFactory{connString: connString}
+}
+
+func (lnf *PGListenerFactory) NewListener() Listener {
+	return NewPGListener(lnf.connString)
+}


### PR DESCRIPTION
This commit adds a package to handle notifications.

They'll be used by the eventstore and the readdb to notify new changes.

Two kind of listener/notify are implemented: a local one and a postgres based
one.