### PR TITLE
eventstore: remove aggregate references.

### DIFF
--- a/api/graphql/schema_test.go
+++ b/api/graphql/schema_test.go
@@ -2891,7 +2891,7 @@ func TestConcurrentChangeRolesTree(t *testing.T) {
 				}
 			}
 			`,
-			Error: fmt.Errorf(`graphql: failed to execute query: pq: duplicate key value violates unique constraint "event_aggregatetype_aggregateid_version_key"`),
+			Error: fmt.Errorf(`graphql: failed to execute query: pq: duplicate key value violates unique constraint "event_category_streamid_version_key"`),
 		},
 	}, true)
 }

--- a/cmd/sircles/dump.go
+++ b/cmd/sircles/dump.go
@@ -85,7 +85,7 @@ func dump(cmd *cobra.Command, args []string) error {
 	i := int64(1)
 	lastSeqNumber := int64(1)
 	for {
-		events, err := es.GetEvents(i, 100)
+		events, err := es.GetAllEvents(i, 100)
 		if err != nil {
 			return err
 		}

--- a/command/command.go
+++ b/command/command.go
@@ -100,7 +100,7 @@ func (s *CommandService) writeEvents(events []eventstore.Event, command *command
 		return nil, err
 	}
 
-	return s.es.WriteEvents(eventsData, aggregateType, aggregateID, version)
+	return s.es.WriteEvents(eventsData, aggregateType.String(), aggregateID, version)
 }
 
 // VERY BIG TODO(sgotti)!!!
@@ -226,7 +226,7 @@ func (s *CommandService) UpdateRootRole(ctx context.Context, c *change.UpdateRoo
 	// TODO(sgotti) split validation from event creation, this will lead to some
 	// code duplication
 
-	version, err := s.es.AggregateVersion(eventstore.RolesTreeAggregateID.String())
+	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -460,7 +460,7 @@ func (s *CommandService) CircleCreateChildRole(ctx context.Context, roleID util.
 		}
 	}
 
-	version, err := s.es.AggregateVersion(eventstore.RolesTreeAggregateID.String())
+	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -662,7 +662,7 @@ func (s *CommandService) CircleUpdateChildRole(ctx context.Context, roleID util.
 	// TODO(sgotti) split validation from event creation, this will lead to some
 	// code duplication
 
-	version, err := s.es.AggregateVersion(eventstore.RolesTreeAggregateID.String())
+	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1140,7 +1140,7 @@ func (s *CommandService) CircleDeleteChildRole(ctx context.Context, roleID util.
 		return res, util.NilID, ErrValidation
 	}
 
-	version, err := s.es.AggregateVersion(eventstore.RolesTreeAggregateID.String())
+	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1229,7 +1229,7 @@ func (s *CommandService) SetRoleAdditionalContent(ctx context.Context, roleID ut
 	}
 	roleAdditionalContent.ID = roleID
 
-	version, err := s.es.AggregateVersion(eventstore.RolesTreeAggregateID.String())
+	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1412,7 +1412,7 @@ func (s *CommandService) createMember(ctx context.Context, c *change.CreateMembe
 	}
 	member.ID = s.uidGenerator.UUID(member.UserName)
 
-	version, err := s.es.AggregateVersion(member.ID.String())
+	version, err := s.es.StreamVersion(member.ID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1592,7 +1592,7 @@ func (s *CommandService) UpdateMember(ctx context.Context, c *change.UpdateMembe
 	member.FullName = c.FullName
 	member.Email = c.Email
 
-	version, err := s.es.AggregateVersion(member.ID.String())
+	version, err := s.es.StreamVersion(member.ID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1660,7 +1660,7 @@ func (s *CommandService) SetMemberPassword(ctx context.Context, memberID util.ID
 		}
 	}
 
-	version, err := s.es.AggregateVersion(memberID.String())
+	version, err := s.es.StreamVersion(memberID.String())
 	if err != nil {
 		return nil, err
 	}
@@ -1735,7 +1735,7 @@ func (s *CommandService) setMemberMatchUID(ctx context.Context, memberID util.ID
 		res.GenericError = errors.Errorf("matchUID already in use")
 	}
 
-	version, err := s.es.AggregateVersion(memberID.String())
+	version, err := s.es.StreamVersion(memberID.String())
 	if err != nil {
 		return nil, err
 	}
@@ -1831,7 +1831,7 @@ func (s *CommandService) CreateTension(ctx context.Context, c *change.CreateTens
 	}
 	tension.ID = s.uidGenerator.UUID(tension.Title)
 
-	version, err := s.es.AggregateVersion(tension.ID.String())
+	version, err := s.es.StreamVersion(tension.ID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -1972,7 +1972,7 @@ func (s *CommandService) UpdateTension(ctx context.Context, c *change.UpdateTens
 		roleChanged = true
 	}
 
-	version, err := s.es.AggregateVersion(tension.ID.String())
+	version, err := s.es.StreamVersion(tension.ID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2048,7 +2048,7 @@ func (s *CommandService) CloseTension(ctx context.Context, c *change.CloseTensio
 		return res, util.NilID, ErrValidation
 	}
 
-	version, err := s.es.AggregateVersion(tension.ID.String())
+	version, err := s.es.StreamVersion(tension.ID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2117,7 +2117,7 @@ func (s *CommandService) CircleAddDirectMember(ctx context.Context, roleID util.
 		return res, util.NilID, ErrValidation
 	}
 
-	version, err := s.es.AggregateVersion(eventstore.RolesTreeAggregateID.String())
+	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2189,7 +2189,7 @@ func (s *CommandService) CircleRemoveDirectMember(ctx context.Context, roleID ut
 		return nil, util.NilID, errors.Errorf("member with id %s is not a member of role %s", memberID, roleID)
 	}
 
-	version, err := s.es.AggregateVersion(eventstore.RolesTreeAggregateID.String())
+	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2290,7 +2290,7 @@ func (s *CommandService) CircleSetLeadLinkMember(ctx context.Context, roleID, me
 		return nil, util.NilID, errors.Errorf("member with id %s doesn't exist", memberID)
 	}
 
-	version, err := s.es.AggregateVersion(eventstore.RolesTreeAggregateID.String())
+	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2420,7 +2420,7 @@ func (s *CommandService) CircleUnsetLeadLinkMember(ctx context.Context, roleID u
 		return res, util.NilID, nil
 	}
 
-	version, err := s.es.AggregateVersion(eventstore.RolesTreeAggregateID.String())
+	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2504,7 +2504,7 @@ func (s *CommandService) CircleSetCoreRoleMember(ctx context.Context, roleType m
 		return nil, util.NilID, errors.Errorf("member with id %s doesn't exist", memberID)
 	}
 
-	version, err := s.es.AggregateVersion(eventstore.RolesTreeAggregateID.String())
+	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2610,7 +2610,7 @@ func (s *CommandService) CircleUnsetCoreRoleMember(ctx context.Context, roleType
 		return res, util.NilID, nil
 	}
 
-	version, err := s.es.AggregateVersion(eventstore.RolesTreeAggregateID.String())
+	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2706,7 +2706,7 @@ func (s *CommandService) RoleAddMember(ctx context.Context, roleID util.ID, memb
 		return nil, util.NilID, errors.Errorf("member with id %s doesn't exist", memberID)
 	}
 
-	version, err := s.es.AggregateVersion(eventstore.RolesTreeAggregateID.String())
+	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2785,7 +2785,7 @@ func (s *CommandService) RoleRemoveMember(ctx context.Context, roleID util.ID, m
 		return nil, util.NilID, errors.Errorf("member with id %s is not a member of role %s", memberID, roleID)
 	}
 
-	version, err := s.es.AggregateVersion(eventstore.RolesTreeAggregateID.String())
+	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2873,7 +2873,7 @@ func (s *CommandService) RoleUpdateMember(ctx context.Context, roleID util.ID, m
 		return nil, util.NilID, errors.Errorf("member with id %s is not a member of role %s", memberID, roleID)
 	}
 
-	version, err := s.es.AggregateVersion(eventstore.RolesTreeAggregateID.String())
+	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
 	if err != nil {
 		return nil, util.NilID, err
 	}
@@ -2935,7 +2935,7 @@ func (s *CommandService) SetupRootRole() (util.ID, error) {
 		Name:     "General",
 	}
 
-	version, err := s.es.AggregateVersion(eventstore.RolesTreeAggregateID.String())
+	version, err := s.es.StreamVersion(eventstore.RolesTreeAggregateID.String())
 	if err != nil {
 		return util.NilID, err
 	}

--- a/db/migration.go
+++ b/db/migration.go
@@ -99,14 +99,14 @@ var migrations = []migration{
 		stmts: []string{
 			// === EventStore ===
 			`--POSTGRES
-             create table event (id uuid not null, sequencenumber bigserial, eventtype varchar not null, aggregatetype varchar not null, aggregateid varchar not null, timestamp timestamptz not null, version bigint not null, data bytea, metadata bytea, PRIMARY KEY (sequencenumber), UNIQUE (aggregatetype, aggregateid, version))`,
+             create table event (id uuid not null, sequencenumber bigserial, eventtype varchar not null, category varchar not null, streamid varchar not null, timestamp timestamptz not null, version bigint not null, data bytea, metadata bytea, PRIMARY KEY (sequencenumber), UNIQUE (category, streamid, version))`,
 			`--SQLITE3
-             create table event (id uuid not null, sequencenumber INTEGER PRIMARY KEY AUTOINCREMENT, eventtype varchar not null, aggregatetype varchar not null, aggregateid varchar not null, timestamp timestamptz not null, version bigint not null, data bytea, metadata bytea, UNIQUE (aggregatetype, aggregateid, version))`,
-			"create index event_aggregateid_version on event(aggregateid, version)",
-			"create index event_aggregatetype on event(aggregatetype)",
+             create table event (id uuid not null, sequencenumber INTEGER PRIMARY KEY AUTOINCREMENT, eventtype varchar not null, category varchar not null, streamid varchar not null, timestamp timestamptz not null, version bigint not null, data bytea, metadata bytea, UNIQUE (category, streamid, version))`,
+			"create index event_streamid on event(streamid, version)",
+			"create index event_category on event(category)",
 
-			// stores the latest version for every aggregate
-			"create table aggregateversion (aggregatetype varchar not null, aggregateid varchar not null, version bigint not null, PRIMARY KEY(aggregateid, version))",
+			// stores the latest version for every stream
+			"create table streamversion (streamid varchar not null, category varchar not null, version bigint not null, PRIMARY KEY(streamid))",
 
 			// === ReadDB ===
 

--- a/eventstore/event.go
+++ b/eventstore/event.go
@@ -22,16 +22,16 @@ type StoredEvent struct {
 	ID             util.ID // unique global event ID
 	SequenceNumber int64   // Global event sequence
 	EventType      EventType
-	AggregateType  AggregateType
-	AggregateID    string
+	Category       string
+	StreamID       string
 	Timestamp      time.Time
-	Version        int64 // Aggregate Version. Increased for every event emitted by a specific aggregate.
+	Version        int64 // Event version in the stream.
 	Data           []byte
 	MetaData       []byte
 }
 
 func (e *StoredEvent) String() string {
-	return fmt.Sprintf("ID: %s, SequenceNumber: %d, EventType: %q, AggregateType: %q, AggregateID: %q, TimeStamp: %q, Version: %d", e.ID, e.SequenceNumber, e.EventType, e.AggregateType, e.AggregateID, e.Timestamp, e.Version)
+	return fmt.Sprintf("ID: %s, SequenceNumber: %d, EventType: %q, Category: %q, StreamID: %q, TimeStamp: %q, Version: %d", e.ID, e.SequenceNumber, e.EventType, e.Category, e.StreamID, e.Timestamp, e.Version)
 }
 
 func (e *StoredEvent) Format(f fmt.State, c rune) {
@@ -106,13 +106,17 @@ func GenEventData(events []Event, correlationID, causationID, groupID, issuerID 
 	return eventsData, nil
 }
 
-type AggregateVersion struct {
-	AggregateType AggregateType
-	AggregateID   string
-	Version       int64 // Aggregate Version. Increased for every event emitted by a specific aggregate.
+type StreamVersion struct {
+	Category string
+	StreamID string
+	Version  int64 // Stream Version. Increased for every event saved in the stream.
 }
 
 type AggregateType string
+
+func (at AggregateType) String() string {
+	return string(at)
+}
 
 const (
 	RolesTreeAggregate AggregateType = "rolestree"

--- a/eventstore/eventstore_test.go
+++ b/eventstore/eventstore_test.go
@@ -54,11 +54,11 @@ func TestWriteEvents(t *testing.T) {
 	}
 	es := NewEventStore(tx)
 
-	if _, err := es.WriteEvents(events, RolesTreeAggregate, RolesTreeAggregateID.String(), 0); err != nil {
+	if _, err := es.WriteEvents(events, RolesTreeAggregate.String(), RolesTreeAggregateID.String(), 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	writtenEvents, err := es.GetEvents(0, 1000)
+	writtenEvents, err := es.GetAllEvents(0, 1000)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -69,11 +69,11 @@ func TestWriteEvents(t *testing.T) {
 		t.Fatalf("expected event sequence %d, got %d", expectedSeq, seq)
 	}
 
-	if _, err := es.WriteEvents(events, RolesTreeAggregate, RolesTreeAggregateID.String(), 3); err != nil {
+	if _, err := es.WriteEvents(events, RolesTreeAggregate.String(), RolesTreeAggregateID.String(), 3); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	writtenEvents, err = es.GetEvents(0, 1000)
+	writtenEvents, err = es.GetAllEvents(0, 1000)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestWriteEvents(t *testing.T) {
 
 	// Write events with different version than the current one
 	expectedErr := fmt.Errorf("current version %d different than provided version %d", 6, 5)
-	if _, err := es.WriteEvents(events, RolesTreeAggregate, RolesTreeAggregateID.String(), 5); err == nil {
+	if _, err := es.WriteEvents(events, RolesTreeAggregate.String(), RolesTreeAggregateID.String(), 5); err == nil {
 		t.Fatalf("expected error %q, got no error", expectedErr)
 	} else {
 		if err.Error() != expectedErr.Error() {
@@ -161,14 +161,14 @@ func TestRestoreEvents(t *testing.T) {
 	}
 	es := NewEventStore(tx)
 
-	if _, err := es.WriteEvents(events1, RolesTreeAggregate, "b1399c23-5b50-4c72-b803-804efaba0cb1", 0); err != nil {
+	if _, err := es.WriteEvents(events1, RolesTreeAggregate.String(), "b1399c23-5b50-4c72-b803-804efaba0cb1", 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, err := es.WriteEvents(events2, RolesTreeAggregate, "65c4dce5-2935-46eb-a71e-3ea1cb4b970c", 0); err != nil {
+	if _, err := es.WriteEvents(events2, RolesTreeAggregate.String(), "65c4dce5-2935-46eb-a71e-3ea1cb4b970c", 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	writtenEvents, err := es.GetEvents(0, 1000)
+	writtenEvents, err := es.GetAllEvents(0, 1000)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestRestoreEvents(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	restoredEvents, err := es.GetEvents(0, 1000)
+	restoredEvents, err := es.GetAllEvents(0, 1000)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/readdb/readdb.go
+++ b/readdb/readdb.go
@@ -2442,7 +2442,7 @@ func (s *readDBService) ApplyEvent(event *eventstore.StoredEvent) error {
 		}
 
 		err := s.tx.Do(func(tx *db.WrappedTx) error {
-			if _, err := tx.Exec("insert into timeline (timestamp, groupid, aggregatetype, aggregateid) values ($1, $2, $3, $4)", tl.Timestamp, metaData.GroupID.UUID, event.AggregateType, event.AggregateID); err != nil {
+			if _, err := tx.Exec("insert into timeline (timestamp, groupid, aggregatetype, aggregateid) values ($1, $2, $3, $4)", tl.Timestamp, metaData.GroupID.UUID, event.Category, event.StreamID); err != nil {
 				return errors.Wrap(err, "failed to insert timeline")
 			}
 			return nil
@@ -2674,7 +2674,7 @@ func (s *readDBService) ApplyEvent(event *eventstore.StoredEvent) error {
 
 	case eventstore.EventTypeTensionCreated:
 		data := data.(*eventstore.EventTensionCreated)
-		tensionID, err := util.IDFromString(event.AggregateID)
+		tensionID, err := util.IDFromString(event.StreamID)
 		if err != nil {
 			return err
 		}
@@ -2698,7 +2698,7 @@ func (s *readDBService) ApplyEvent(event *eventstore.StoredEvent) error {
 
 	case eventstore.EventTypeTensionUpdated:
 		data := data.(*eventstore.EventTensionUpdated)
-		tensionID, err := util.IDFromString(event.AggregateID)
+		tensionID, err := util.IDFromString(event.StreamID)
 		if err != nil {
 			return err
 		}
@@ -2715,7 +2715,7 @@ func (s *readDBService) ApplyEvent(event *eventstore.StoredEvent) error {
 
 	case eventstore.EventTypeTensionRoleChanged:
 		data := data.(*eventstore.EventTensionRoleChanged)
-		tensionID, err := util.IDFromString(event.AggregateID)
+		tensionID, err := util.IDFromString(event.StreamID)
 		if err != nil {
 			return err
 		}
@@ -2733,7 +2733,7 @@ func (s *readDBService) ApplyEvent(event *eventstore.StoredEvent) error {
 
 	case eventstore.EventTypeTensionClosed:
 		data := data.(*eventstore.EventTensionClosed)
-		tensionID, err := util.IDFromString(event.AggregateID)
+		tensionID, err := util.IDFromString(event.StreamID)
 		if err != nil {
 			return err
 		}
@@ -2754,7 +2754,7 @@ func (s *readDBService) ApplyEvent(event *eventstore.StoredEvent) error {
 
 	case eventstore.EventTypeMemberCreated:
 		data := data.(*eventstore.EventMemberCreated)
-		memberID, err := util.IDFromString(event.AggregateID)
+		memberID, err := util.IDFromString(event.StreamID)
 		if err != nil {
 			return err
 		}
@@ -2771,7 +2771,7 @@ func (s *readDBService) ApplyEvent(event *eventstore.StoredEvent) error {
 
 	case eventstore.EventTypeMemberUpdated:
 		data := data.(*eventstore.EventMemberUpdated)
-		memberID, err := util.IDFromString(event.AggregateID)
+		memberID, err := util.IDFromString(event.StreamID)
 		if err != nil {
 			return err
 		}
@@ -2788,7 +2788,7 @@ func (s *readDBService) ApplyEvent(event *eventstore.StoredEvent) error {
 
 	case eventstore.EventTypeMemberPasswordSet:
 		data := data.(*eventstore.EventMemberPasswordSet)
-		memberID, err := util.IDFromString(event.AggregateID)
+		memberID, err := util.IDFromString(event.StreamID)
 		if err != nil {
 			return err
 		}
@@ -2807,7 +2807,7 @@ func (s *readDBService) ApplyEvent(event *eventstore.StoredEvent) error {
 		}
 	case eventstore.EventTypeMemberAvatarSet:
 		data := data.(*eventstore.EventMemberAvatarSet)
-		memberID, err := util.IDFromString(event.AggregateID)
+		memberID, err := util.IDFromString(event.StreamID)
 		if err != nil {
 			return err
 		}

--- a/search/search.go
+++ b/search/search.go
@@ -138,7 +138,7 @@ func (s *SearchEngine) eventsPoller() {
 	}
 
 	for {
-		events, err := es.GetEvents(eventSeqNumber+1, 100)
+		events, err := es.GetAllEvents(eventSeqNumber+1, 100)
 		if err != nil {
 			log.Errorf("cannot get events: %+v", err)
 			return
@@ -307,14 +307,14 @@ func (s *SearchEngine) HandlEvent(event *eventstore.StoredEvent) error {
 	case eventstore.EventTypeTensionClosed:
 
 	case eventstore.EventTypeMemberCreated:
-		memberID, err := util.IDFromString(event.AggregateID)
+		memberID, err := util.IDFromString(event.StreamID)
 		if err != nil {
 			return err
 		}
 		reindexMembers = append(reindexMembers, memberID)
 
 	case eventstore.EventTypeMemberUpdated:
-		memberID, err := util.IDFromString(event.AggregateID)
+		memberID, err := util.IDFromString(event.StreamID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Remove references to aggregate. Every aggregate events will be saved in a
stream. The aggregateType becomes a category.